### PR TITLE
Support code object v4

### DIFF
--- a/amd/bitops/ops.go
+++ b/amd/bitops/ops.go
@@ -1,5 +1,7 @@
 package bitops
 
+import "encoding/binary"
+
 // ExtractBitsFromU64 will get the bits from loInclude to hiInclude.
 func ExtractBitsFromU64(num uint64, loInclude, hiInclude int) uint64 {
 	var mask uint64
@@ -16,6 +18,11 @@ func ExtractBitsFromU32(num uint32, loInclude, hiInclude int) uint32 {
 	mask = ((1 << (hiInclude - loInclude + 1)) - 1) << loInclude
 	extracted = (num & mask) >> loInclude
 	return extracted
+}
+
+// ExtractBit extracts a single bit from a uint32 number.
+func ExtractBit(number uint32, bitPosition int) uint32 {
+	return (number >> bitPosition) & 1
 }
 
 // SignExt updates all the bits beyond the signBit to be the same as the sign
@@ -36,4 +43,14 @@ func SignExt(in uint64, signBit int) (out uint64) {
 	}
 
 	return out
+}
+
+// BytesToU32 decode a uint32 number from bytes
+func BytesToU32(data []byte) uint32 {
+	return binary.LittleEndian.Uint32(data)
+}
+
+// BytesToU64 decode a uint64 number from bytes
+func BytesToU64(data []byte) uint64 {
+	return binary.LittleEndian.Uint64(data)
 }

--- a/amd/kernels/codeobject.go
+++ b/amd/kernels/codeobject.go
@@ -1,0 +1,188 @@
+package kernels
+
+import (
+	"debug/elf"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/sarchlab/mgpusim/v4/amd/insts"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+const (
+	// CodeObjectVersionV2 represents the version of the code object.
+	UndefinedCodeObjectVersion = 0
+	CodeObjectVersionV2        = 2
+	CodeObjectVersionV3        = 3
+	CodeObjectVersionV4        = 4
+	CodeObjectVersionV5        = 5
+)
+
+type CodeObjectVersion int
+
+// AMDHSAVersion represents the version of the AMD HSA code object.
+
+type AMDHSAVersion struct {
+	Major uint32
+	Minor uint32
+}
+
+func parseFromCodeObjectVersionV3ToV5(
+	note []byte,
+) (version CodeObjectVersion) {
+	kernelsIndex := strings.Index(string(note), "amdhsa.kernels")
+	if kernelsIndex == -1 {
+		panic("amdhsa.kernels not found in note section")
+	}
+
+	var metadata map[string]interface{}
+	err := msgpack.Unmarshal(note[kernelsIndex-2:], &metadata)
+	if err != nil {
+		panic(fmt.Sprintf("failed to unmarshal note section: %v", err))
+	}
+
+	amdHSAVersion := AMDHSAVersion{
+		Major: uint32(metadata["amdhsa.version"].([]interface{})[0].(int8)),
+		Minor: uint32(metadata["amdhsa.version"].([]interface{})[1].(int8)),
+	}
+
+	if amdHSAVersion.Major == 1 && amdHSAVersion.Minor == 1 {
+		return CodeObjectVersionV4
+	} else {
+		log.Panicf("unsupported AMD HSA version: %d.%d", amdHSAVersion.Major, amdHSAVersion.Minor)
+	}
+
+	return UndefinedCodeObjectVersion
+}
+
+func addCodeObjectV2(
+	data []byte,
+	kernelName string,
+	executable *elf.File,
+) *insts.HsaCo {
+	symbols, err := executable.Symbols()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	textSection := executable.Section(".text")
+	if textSection == nil {
+		log.Fatal(".text section is not found")
+	}
+
+	textSectionData, err := textSection.Data()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// An empty kernel name is for the case where the symbol is not generated.
+	// Use the whole text section in this case.
+	if kernelName == "" {
+		hsaco := insts.NewHsaCoFromData(textSectionData)
+		return hsaco
+	}
+
+	for _, symbol := range symbols {
+		if symbol.Name == kernelName {
+			offset := symbol.Value - textSection.Offset
+			hsacoData := textSectionData[offset : offset+symbol.Size]
+			hsaco := insts.NewHsaCoFromData(hsacoData)
+			symbolCopy := symbol
+			hsaco.Symbol = &symbolCopy
+
+			// fmt.Println(hsaco.Info())
+
+			return hsaco
+		}
+	}
+
+	return nil
+}
+
+func addCodeObjectV4(
+	data []byte,
+	kernelName string,
+	executable *elf.File,
+) *insts.HsaCo {
+	symbols, err := executable.Symbols()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rodataSection := executable.Section(".rodata")
+	if rodataSection == nil {
+		panic("cannot find rodata sec")
+	}
+
+	rodataSecData, err := rodataSection.Data()
+	if err != nil {
+		panic(err)
+	}
+
+	textSection := executable.Section(".text")
+	if textSection == nil {
+		panic("cannot find text sec")
+	}
+
+	noteSection := executable.Section(".note")
+	if noteSection == nil {
+		panic("cannot find note sec")
+	}
+
+	noteSecData, err := noteSection.Data()
+	if err != nil {
+		panic(err)
+	}
+
+	kernelsIndex := strings.Index(string(noteSecData), "amdhsa.kernels")
+	if kernelsIndex == -1 {
+		panic("amdhsa.kernels not found in note section")
+	}
+
+	var metadata map[string]interface{}
+	err = msgpack.Unmarshal(noteSecData[kernelsIndex-2:], &metadata)
+	if err != nil {
+		panic(fmt.Sprintf("failed to unmarshal note section: %v", err))
+	}
+
+	// An empty kernel name is for the case where the symbol is not generated.
+	// Use the whole text section in this case.
+	if kernelName == "" {
+		panic("kernel name must be specified in the case of CodeObjectVersionV4")
+	}
+
+	for _, descriptorSymbol := range symbols {
+		if descriptorSymbol.Name == kernelName+".kd" {
+			descriptorOffset := descriptorSymbol.Value - rodataSection.Offset
+			kdData := rodataSecData[descriptorOffset : descriptorOffset+descriptorSymbol.Size]
+
+			hsacoHeader := insts.NewHsacoHeader(kernelName, kdData, metadata)
+
+			hsacoHeader.CodeVersionMajor = 1
+			hsacoHeader.CodeVersionMinor = 1
+
+			for _, kernelSymbol := range symbols {
+				if kernelSymbol.Name == kernelName {
+					offset := kernelSymbol.Value - textSection.Addr + textSection.Offset
+
+					kernelData := data[offset : offset+kernelSymbol.Size]
+
+					hsaco := insts.NewHsaCoFromHeader(kernelData, hsacoHeader)
+					symbolCopy := kernelSymbol
+					hsaco.Symbol = &symbolCopy
+
+					// fmt.Println(hsaco.Info())
+
+					// Unlike CodeObjectVersionV2, we directly move instruction data
+					// to the beginning of the code object.
+					hsaco.KernelCodeEntryByteOffset = 0
+
+					return hsaco
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/amd/kernels/loadprogram.go
+++ b/amd/kernels/loadprogram.go
@@ -4,9 +4,35 @@ import (
 	"bytes"
 	"debug/elf"
 	"log"
+	"regexp"
 
 	"github.com/sarchlab/mgpusim/v4/amd/insts"
 )
+
+func parseNote(
+	file *elf.File,
+) CodeObjectVersion {
+	noteSection := file.Section(".note")
+	if noteSection == nil {
+		panic(".note section is not found")
+	}
+
+	note, err := noteSection.Data()
+	if err != nil {
+		panic("cannot read note")
+	}
+
+	// determine the Code Object Version
+	// if the note contains "amdhsa.version", then it is version 3 or later
+	// otherwise, it is version 2
+	amdhsaRegEx := regexp.MustCompile(`amdhsa.version`)
+	amdhsaStr := string(amdhsaRegEx.Find(note))
+	if amdhsaStr == "" {
+		return CodeObjectVersionV2
+	}
+
+	return parseFromCodeObjectVersionV3ToV5(note)
+}
 
 // LoadProgram loads program
 func LoadProgram(filePath, kernelName string) *insts.HsaCo {
@@ -61,40 +87,21 @@ func LoadProgramFromMemory(data []byte, kernelName string) *insts.HsaCo {
 		log.Fatal(err)
 	}
 
-	symbols, err := executable.Symbols()
-	if err != nil {
-		log.Fatal(err)
-	}
+	codeObjectVersion := parseNote(executable)
 
-	textSection := executable.Section(".text")
-	if textSection == nil {
-		log.Fatal(".text section is not found")
-	}
-
-	textSectionData, err := textSection.Data()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// An empty kernel name is for the case where the symbol is not generated.
-	// Use the whole text section in this case.
-	if kernelName == "" {
-		hsaco := insts.NewHsaCoFromData(textSectionData)
-		return hsaco
-	}
-
-	for _, symbol := range symbols {
-		if symbol.Name == kernelName {
-			offset := symbol.Value - textSection.Offset
-			hsacoData := textSectionData[offset : offset+symbol.Size]
-			hsaco := insts.NewHsaCoFromData(hsacoData)
-			symbolCopy := symbol
-			hsaco.Symbol = &symbolCopy
-
-			//fmt.Println(hsaco.Info())
-
-			return hsaco
-		}
+	switch codeObjectVersion {
+	case UndefinedCodeObjectVersion:
+		log.Panic("unsupported Code Object Version")
+	case CodeObjectVersionV2:
+		return addCodeObjectV2(data, kernelName, executable)
+	case CodeObjectVersionV3:
+		log.Panicf("unimplemented Code Object Version: %d", codeObjectVersion)
+	case CodeObjectVersionV4:
+		return addCodeObjectV4(data, kernelName, executable)
+	case CodeObjectVersionV5:
+		log.Panicf("unimplemented Code Object Version: %d", codeObjectVersion)
+	default:
+		log.Panicf("unsupported Code Object Version: %d", codeObjectVersion)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 
 require github.com/sirupsen/logrus v1.9.3
 
+require github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/syifan/goseth v0.1.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/image v0.24.0 // indirect
 	golang.org/x/net v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,10 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=


### PR DESCRIPTION
I have implemented the code object v4 parser to support the newest ROCm. The newest ROCm support code object v4 and v5, so I think code object v4 is enough for simulating HIPCC applications.

WARN: `InstructionData()` in `amd/insts/hsaco.go` should return `o.Data[0:]` when using code object v4.