### PR TITLE
Try to fix the -cpi-stack error in DNN training workload

### DIFF
--- a/amd/benchmarks/dnn/dataset/imagenet/datasource.go
+++ b/amd/benchmarks/dnn/dataset/imagenet/datasource.go
@@ -59,7 +59,7 @@ func (ds *DataSource) NextBatch(batchSize int) (
 		}
 	}
 
-	data = ds.to.CreateWithData(rawData, []int{count, 3, 224, 224}, "NCHW")
+	data = ds.to.CreateWithData(rawData, []int{count, 3, imageInputSize, imageInputSize}, "NCHW")
 
 	ds.currPtr += count
 

--- a/amd/benchmarks/dnn/dataset/imagenet/imagenet.go
+++ b/amd/benchmarks/dnn/dataset/imagenet/imagenet.go
@@ -14,6 +14,9 @@ import (
 	"github.com/disintegration/imaging"
 )
 
+// The DataSet can provide imagenet data.
+const imageInputSize = 224
+
 var imagenetDataFolder = flag.String("imagenet-data-folder", "",
 	"Specifies where the imagenet data is located at.")
 
@@ -92,7 +95,7 @@ func (d *DataSet) HasNext() bool {
 // in the dataset.
 func (d *DataSet) Next() (imageData []byte, labelData byte) {
 	var err error
-	var imageArray [224 * 224 * 3]byte
+	var imageArray [imageInputSize * imageInputSize * 3]byte
 	var label byte
 	var imagePath string
 	var className string
@@ -111,14 +114,15 @@ func (d *DataSet) Next() (imageData []byte, labelData byte) {
 	defer f.Close()
 
 	img, _, err := image.Decode(f)
-	img224 := imaging.Resize(img, 224, 224, imaging.Lanczos)
+	imgResized := imaging.Resize(img, imageInputSize, imageInputSize, imaging.Lanczos)
 	dieOnErr(err)
-	for i := 0; i < 224; i++ {
-		for j := 0; j < 224; j++ {
-			r, g, b, _ := img224.At(i, j).RGBA()
-			imageArray[i*j] = uint8(r >> 8)
-			imageArray[i*j+224*224] = uint8(g >> 8)
-			imageArray[i*j+224*224*2] = uint8(b >> 8)
+	for i := 0; i < imageInputSize; i++ {
+		for j := 0; j < imageInputSize; j++ {
+			r, g, b, _ := imgResized.At(i, j).RGBA()
+			idx := i*imageInputSize + j
+			imageArray[idx] = uint8(r >> 8)
+			imageArray[idx+imageInputSize*imageInputSize] = uint8(g >> 8)
+			imageArray[idx+imageInputSize*imageInputSize*2] = uint8(b >> 8)
 		}
 	}
 

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -555,10 +555,10 @@ func (cu *ComputeUnit) handleScalarDataLoadReturn(
 	cu.InFlightScalarMemAccess = cu.InFlightScalarMemAccess[1:]
 
 	tracing.TraceReqFinalize(req, cu)
-	cu.logInstTask(wf, info.Inst, true)
 
 	if cu.isLastRead(req) {
 		wf.OutstandingScalarMemAccess--
+		cu.logInstTask(wf, info.Inst, true)
 	}
 }
 


### PR DESCRIPTION
Summary:
*1. I tried to solve the problem shown in #71 by moving one line in timing/computeunit.go
2. I modified the imagenet.go and datasource.go in "amd/benchmarks/dnn/dataset/imagenet"  since the previous implementation used a hardcoded image size (224x224) and incorrectly calculated pixel indexing when flattening the RGB channels.

Hi,

This pull request tries to solve the problem shown in #71. 

### Bug Summary
In **timing mode**, running the default vgg16 workload leads to a panic after a short period.


###  How to Reproduce
This bug is triggered when using workloads like `conv2d` or `vgg16` with `-timing` mode and `-report-cpi-stack` enabled (it also happens with `-report-all`).

You can reliably reproduce it using:
```bash
./conv2d -timing -report-cpi-stack
```

###  Root Cause
In `scalarunit.go`, scalar instructions sometimes require two req_out messages to fetch data spanning two cache lines.

However, in `computeunit.go`, the scalar instruction is considered complete as soon as the first req_out returns. When the second req_out comes back, the parent task has already been freed from the inflight list, leading to a panic when attempting to finalize it again.

In `scalarunit.go`:
``` go
func (u *ScalarUnit) executeSMEMLoad(byteSize int) bool {
    // ...
	for bytesLeft > 0 {                               // -> This loop will generate more than one req_out task if the Instruction needs to request more than 1 cache line
		bytesLeftInCacheline := u.byteInCacheline(curr, bytesLeft)
		bytesLeft -= bytesLeftInCacheline
                //...
 }
   //...
}
```

With respect to `computeunit.go`, please view the function I modified.

### Test

To validate the fix, I created a custom `vgg8` workload by reducing the number of model blocks and shrinking the image input size for faster testing. As estimated, the vgg16 may run around 100 days since my vgg8 workload run for around 1 day.

I verified that the bug no longer appears when running the following commands:

```bash
./conv2d -timing -report-all
./tinyvgg -timing -report-all
```