### PR TITLE
Investigate correctness of unified memory fix for multi-GPU system

### DIFF
--- a/amd/samples/runner/timingconfig/builder.go
+++ b/amd/samples/runner/timingconfig/builder.go
@@ -151,7 +151,8 @@ func (b *Builder) createGPUBuilder(
 		WithNumMemoryBank(16).
 		WithLog2MemoryBankInterleavingSize(7).
 		WithLog2PageSize(b.log2PageSize).
-		WithGlobalStorage(b.globalStorage)
+		WithGlobalStorage(b.globalStorage).
+		WithGPUDriver(gpuDriver)
 
 	b.createRDMAAddressMapper()
 
@@ -250,7 +251,7 @@ func (b *Builder) createGPU(
 	// gpu.CommandProcessor.Driver = gpuDriver.GetPortByName("GPU")
 
 	b.configRDMAEngine(gpu)
-	// b.configPMC(gpu, gpuDriver, pmcAddressTable)
+	b.configPMC(gpu, gpuDriver)
 
 	pcieConnector.PlugInDevice(pcieSwitchID, gpu.Ports())
 
@@ -267,15 +268,10 @@ func (b *Builder) configRDMAEngine(
 		gpu.GetPortByName("RDMAData").AsRemote())
 }
 
-// func (b *Builder) configPMC(
-// 	gpu *GPU,
-// 	gpuDriver *driver.Driver,
-// 	addrTable *mem.BankedAddressPortMapper,
-// ) {
-// 	gpu.PMC.RemotePMCAddressTable = addrTable
-// 	addrTable.LowModules = append(
-// 		addrTable.LowModules,
-// 		gpu.PMC.GetPortByName("Remote").AsRemote())
-// 	gpuDriver.RemotePMCPorts = append(
-// 		gpuDriver.RemotePMCPorts, gpu.PMC.GetPortByName("Remote"))
-// }
+func (b *Builder) configPMC(
+	gpu *sim.Domain,
+	gpuDriver *driver.Driver,
+) {
+	gpuDriver.RemotePMCPorts = append(
+		gpuDriver.RemotePMCPorts, gpu.GetPortByName("PageMigrationController"))
+}

--- a/amd/timing/cp/builder.go
+++ b/amd/timing/cp/builder.go
@@ -98,6 +98,7 @@ func (Builder) createPorts(cp *CommandProcessor, name string) {
 	cp.ToTLBs = sim.NewPort(cp, 4096, 4096, name+".ToTLBs")
 	cp.ToRDMA = sim.NewPort(cp, 4096, 4096, name+".ToRDMA")
 	cp.ToPMC = sim.NewPort(cp, 4096, 4096, name+".ToPMC")
+	cp.ToROBs = sim.NewPort(cp, 4096, 4096, name+".ToROBs")
 	cp.ToAddressTranslators = sim.NewPort(cp, 4096, 4096,
 		name+".ToAddressTranslators")
 	cp.ToCaches = sim.NewPort(cp, 4096, 4096, name+".ToCaches")

--- a/amd/timing/cp/commandprocessor.go
+++ b/amd/timing/cp/commandprocessor.go
@@ -18,6 +18,7 @@ type CommandProcessor struct {
 	DMAEngine          sim.Port
 	Driver             sim.Port
 	TLBs               []sim.Port
+	ROBs               []sim.Port
 	CUs                []sim.RemotePort
 	AddressTranslators []sim.Port
 	RDMA               sim.Port
@@ -31,6 +32,7 @@ type CommandProcessor struct {
 	ToDriver             sim.Port
 	ToDMA                sim.Port
 	ToCUs                sim.Port
+	ToROBs               sim.Port
 	ToTLBs               sim.Port
 	ToAddressTranslators sim.Port
 	ToCaches             sim.Port
@@ -41,6 +43,8 @@ type CommandProcessor struct {
 	currFlushRequest     *protocol.FlushReq
 
 	numCUAck                     uint64
+	numROBFlushAck               uint64
+	numROBRestartAck             uint64
 	numAddrTranslationFlushAck   uint64
 	numAddrTranslationRestartAck uint64
 	numTLBAck                    uint64


### PR DESCRIPTION
I attempted to fix the unified memory issue in the latest version of MGPUSim for multi-GPU systems.

In my current implementation, I discard all in-flight translation and memory requests during page migration, and let compute units reissue the memory requests after migration completes.
﻿
I modified both Akita and MGPUSim to support this behavior. However, I am not sure whether this approach is functionally correct.

https://github.com/MaxKev1n/akita_public/commit/719422d3016a45ab985a1c235ad795633ef2b417
https://github.com/MaxKev1n/mgpusim_public/commit/37c5a3349ee4f72f91f0478dc54d2e64465e67a0