### PR TITLE
Tracing instrumentation on akita beta.7: fix task leaks + add blocked-time milestones

### DIFF
--- a/.github/workflows/mgpusim_test.yml
+++ b/.github/workflows/mgpusim_test.yml
@@ -152,8 +152,7 @@ jobs:
 
   gcn3_emu_test:
     name: GCN3 Emulation Test
-    runs-on:
-      group: Github-Large-1
+    runs-on: Github-Large-1
     needs: [unit_test]
     steps:
       - name: Checkout
@@ -180,8 +179,7 @@ jobs:
 
   gcn3_single_gpu_timing_test:
     name: GCN3 Single GPU Timing Test (${{ matrix.shard.name }})
-    runs-on:
-      group: Github-Large-1
+    runs-on: Github-Large-1
     needs: [gcn3_emu_test]
     strategy:
       fail-fast: false
@@ -226,8 +224,7 @@ jobs:
 
   cdna3_emu_test:
     name: CDNA3 Emulation Test
-    runs-on:
-      group: Github-Large-1
+    runs-on: Github-Large-1
     needs: [unit_test]
     steps:
       - name: Checkout
@@ -254,8 +251,7 @@ jobs:
 
   cdna3_single_gpu_timing_test:
     name: CDNA3 Single GPU Timing Test
-    runs-on:
-      group: Github-Large-1
+    runs-on: Github-Large-1
     needs: [cdna3_emu_test]
     steps:
       - name: Checkout

--- a/.github/workflows/mgpusim_test.yml
+++ b/.github/workflows/mgpusim_test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   compile:
     name: Compile
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -62,7 +62,7 @@ jobs:
 
   unit_test:
     name: Unit Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [compile, lint]
     steps:
       - name: Checkout
@@ -94,7 +94,7 @@ jobs:
 
   deterministicity_test:
     name: Deterministicity Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [unit_test]
     steps:
       - name: Checkout
@@ -124,7 +124,7 @@ jobs:
 
   disassembler_test:
     name: Disassembler Test (GFX942)
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [compile]
     steps:
       - name: Checkout
@@ -152,7 +152,8 @@ jobs:
 
   gcn3_emu_test:
     name: GCN3 Emulation Test
-    runs-on: self-hosted
+    runs-on:
+      group: Github-Large-1
     needs: [unit_test]
     steps:
       - name: Checkout
@@ -179,7 +180,8 @@ jobs:
 
   gcn3_single_gpu_timing_test:
     name: GCN3 Single GPU Timing Test (${{ matrix.shard.name }})
-    runs-on: self-hosted
+    runs-on:
+      group: Github-Large-1
     needs: [gcn3_emu_test]
     strategy:
       fail-fast: false
@@ -224,7 +226,8 @@ jobs:
 
   cdna3_emu_test:
     name: CDNA3 Emulation Test
-    runs-on: self-hosted
+    runs-on:
+      group: Github-Large-1
     needs: [unit_test]
     steps:
       - name: Checkout
@@ -251,7 +254,8 @@ jobs:
 
   cdna3_single_gpu_timing_test:
     name: CDNA3 Single GPU Timing Test
-    runs-on: self-hosted
+    runs-on:
+      group: Github-Large-1
     needs: [cdna3_emu_test]
     steps:
       - name: Checkout

--- a/.github/workflows/mgpusim_test.yml
+++ b/.github/workflows/mgpusim_test.yml
@@ -1,6 +1,9 @@
 name: MGPUSim Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   compile:

--- a/amd/timing/TRACING.md
+++ b/amd/timing/TRACING.md
@@ -47,15 +47,16 @@ reason. Admission waits hang on the port's incoming-buffer task (via
 | CP | `ToDMA` | network_busy | waited for the downstream DMA port (buffer task) |
 | RDMA | `remote` | data | waited for the round trip to the other side (req_in) |
 | CU | `vmem-inflight` | hardware_resource | waited for an in-flight vector-mem slot (inst) |
-| CU | `coalesce` | work | coalescing/transaction-issue before the first vector-mem request is sent, backed by a `pipeline` subtask (inst) |
+| CU | `coalesce` | work | coalescing/transaction-issue, until the first vector-mem transaction is ready to send, backed by a `pipeline` subtask (inst) |
 | CU | `vmem` / `smem` | data | waited for the vector/scalar memory response (inst) |
 | CU | `s_waitcnt` | data | S_WAITCNT waited for outstanding memory (inst) |
 | CU | `s_endpgm` | data | S_ENDPGM drained outstanding memory (inst) |
 
 A vector-memory `inst` task is tiled into three phases: `vmem-inflight`
 (`hardware_resource`, the in-flight slot is acquired at execute) → `coalesce`
-(`work`, the first transaction is sent) → `vmem` (`data`, the last response
-returns, at the task end). The `coalesce` interval is the unit *doing work*
+(`work`, until the first transaction is ready to send) → `vmem` (`data`, the
+last response returns, at the task end). The `coalesce` interval is the unit
+*doing work*
 (coalescing + transaction-issue pipeline), not blocking, so it is a `work`
 milestone backed by a child `pipeline`/`coalesce` subtask that spans it (per the
 "work ⇒ subtask" coverage rule). The request is not yet outstanding before the

--- a/amd/timing/TRACING.md
+++ b/amd/timing/TRACING.md
@@ -47,18 +47,20 @@ reason. Admission waits hang on the port's incoming-buffer task (via
 | CP | `ToDMA` | network_busy | waited for the downstream DMA port (buffer task) |
 | RDMA | `remote` | data | waited for the round trip to the other side (req_in) |
 | CU | `vmem-inflight` | hardware_resource | waited for an in-flight vector-mem slot (inst) |
-| CU | `coalesce` | hardware_resource | coalescing/transaction-issue before the first vector-mem request is sent (inst) |
+| CU | `coalesce` | work | coalescing/transaction-issue before the first vector-mem request is sent, backed by a `pipeline` subtask (inst) |
 | CU | `vmem` / `smem` | data | waited for the vector/scalar memory response (inst) |
 | CU | `s_waitcnt` | data | S_WAITCNT waited for outstanding memory (inst) |
 | CU | `s_endpgm` | data | S_ENDPGM drained outstanding memory (inst) |
 
-A vector-memory `inst` task is tiled into three phases: `vmem-inflight` (the
-in-flight slot is acquired, at coalesce/execute) → `coalesce` (the first
-transaction is actually sent) → `vmem` `data` (the last response returns, at the
-task end). The `coalesce` milestone matters because the request is not yet
-outstanding between admission and first send, so that interval must not be
-attributed to the data wait — the `data` interval then lines up exactly with the
-child `req_out` transaction bars.
+A vector-memory `inst` task is tiled into three phases: `vmem-inflight`
+(`hardware_resource`, the in-flight slot is acquired at execute) → `coalesce`
+(`work`, the first transaction is sent) → `vmem` (`data`, the last response
+returns, at the task end). The `coalesce` interval is the unit *doing work*
+(coalescing + transaction-issue pipeline), not blocking, so it is a `work`
+milestone backed by a child `pipeline`/`coalesce` subtask that spans it (per the
+"work ⇒ subtask" coverage rule). The request is not yet outstanding before the
+first send, so that interval must not be attributed to the data wait — the
+`data` interval then lines up exactly with the child `req_out` transaction bars.
 
 Each component package has a `milestone_tracing_test.go` (or equivalent)
 asserting its milestones with a recording tracer.

--- a/amd/timing/TRACING.md
+++ b/amd/timing/TRACING.md
@@ -1,0 +1,69 @@
+# Timing-model tracing / instrumentation
+
+MGPUSim builds its simulation through Akita's `simulation.Simulation`, which is
+the registrar for every component and port. `RegisterComponent` auto-attaches
+the vis `DBTracer` (`CollectTrace`) and `RegisterPort` auto-attaches the
+incoming- and outgoing-buffer tracers. So every timing component — the CU, the
+Command Processor, the DMA engine, the dispatchers, the RDMA engine — and the
+reused Akita `mem/` hierarchy (caches, TLBs, address translators, ROBs, DRAM)
+are traced when `-trace-vis` is on, and every port gets free buffer-queueing
+tasks. This document covers the **MGPUSim-authored** instrumentation; the
+`mem/` components are instrumented inside Akita.
+
+Requires Akita **v5.0.0-beta.7** or later (the buffer-admission registry
+`MsgIDAtIncomingBuffer`, the reset helpers `EndReqInOnReset`/`EndTaskOnReset`,
+and `MilestoneKindWork`).
+
+## Task lifecycle
+
+| Component | req_in | req_out | internal tasks |
+|---|---|---|---|
+| CU | MapWGReq (per work-group) | inst fetch, scalar/vector mem | `wavefront`, `inst`, `fetch`, SIMD `pipeline` |
+| Command Processor | LaunchKernelReq, MemCopy, FlushReq | cloned MemCopy → DMA | — |
+| DMA | MemCopy | per-unit Read/Write → mem | — |
+| Dispatcher | — | MapWGReq → CU | — |
+| RDMA | forwarded request | forwarded clone | — |
+
+### Reset / flush teardown
+
+A CU pipeline flush discards in-flight work; the tracing tasks of that work are
+ended so they do not leak (`endInflightTracingTasks`, `SIMDUnit.Flush`, the
+`populateShadowBuffers` req_out teardown, and the sampled-run work-group
+completion). The CP's `FlushReq` req_in is completed when the flush-done
+response is sent. See `flush_tracing_test.go` (`tracingtest.LeakRecorder`).
+
+## Milestones (blocked-time attribution)
+
+Milestones mark when a blocking condition resolves; the interval from the
+previous milestone (or task start) to a milestone is time spent blocked on that
+reason. Admission waits hang on the port's incoming-buffer task (via
+`MsgIDAtIncomingBuffer`); processing waits hang on the req_in / inst task.
+
+| Component | Milestone | Kind | Marks |
+|---|---|---|---|
+| DMA | `processing slot` | hardware_resource | waited for a concurrency slot (buffer task) |
+| DMA | `ToMem` | data | waited for the memory round trip (req_in) |
+| CP | `dispatcher` | hardware_resource | waited for a free dispatcher (buffer task) |
+| CP | `ToDMA` | network_busy | waited for the downstream DMA port (buffer task) |
+| RDMA | `remote` | data | waited for the round trip to the other side (req_in) |
+| CU | `vmem-inflight` | hardware_resource | waited for an in-flight vector-mem slot (inst) |
+| CU | `s_waitcnt` | data | S_WAITCNT waited for outstanding memory (inst) |
+| CU | `s_endpgm` | data | S_ENDPGM drained outstanding memory (inst) |
+
+Each component package has a `milestone_tracing_test.go` (or equivalent)
+asserting its milestones with a recording tracer.
+
+## Known limitations / intentional gaps
+
+- **CU pre-issue stalls are not instrumented.** The scheduler's structural
+  hazard (`CanAcceptWave`) and the port back-pressure (`!CanSend`) stalls happen
+  *before* the instruction's task exists, so there is no task to attribute the
+  wait to. The same applies to the dispatcher's free-CU and ToCUs-send waits.
+- **SIMD `pipeline` tasks live on the SIMD-unit domain on purpose** — the
+  per-SIMD `BusyTimeTracer` (report.go) needs them there. The cross-domain
+  parent ("inst" on cu.comp) resolves because the vis DBTracer is one instance
+  on both domains.
+- **Control plane** (shootdown / GPU-restart / RDMA drain in `ctrlMiddleware`)
+  is not instrumented beyond completing the FlushReq req_in.
+- **Tags** are not emitted; the read/write/direction distinctions live in each
+  task's `What`/`Detail`.

--- a/amd/timing/TRACING.md
+++ b/amd/timing/TRACING.md
@@ -47,8 +47,14 @@ reason. Admission waits hang on the port's incoming-buffer task (via
 | CP | `ToDMA` | network_busy | waited for the downstream DMA port (buffer task) |
 | RDMA | `remote` | data | waited for the round trip to the other side (req_in) |
 | CU | `vmem-inflight` | hardware_resource | waited for an in-flight vector-mem slot (inst) |
+| CU | `vmem` / `smem` | data | waited for the vector/scalar memory response (inst) |
 | CU | `s_waitcnt` | data | S_WAITCNT waited for outstanding memory (inst) |
 | CU | `s_endpgm` | data | S_ENDPGM drained outstanding memory (inst) |
+
+A memory instruction's `inst` task ends when its last response returns; the
+`vmem`/`smem` `data` milestone lands at that moment, so the round-trip interval
+between the request leaving and the data returning is attributed rather than
+left as an unexplained gap at the end of the bar.
 
 Each component package has a `milestone_tracing_test.go` (or equivalent)
 asserting its milestones with a recording tracer.

--- a/amd/timing/TRACING.md
+++ b/amd/timing/TRACING.md
@@ -47,14 +47,18 @@ reason. Admission waits hang on the port's incoming-buffer task (via
 | CP | `ToDMA` | network_busy | waited for the downstream DMA port (buffer task) |
 | RDMA | `remote` | data | waited for the round trip to the other side (req_in) |
 | CU | `vmem-inflight` | hardware_resource | waited for an in-flight vector-mem slot (inst) |
+| CU | `coalesce` | hardware_resource | coalescing/transaction-issue before the first vector-mem request is sent (inst) |
 | CU | `vmem` / `smem` | data | waited for the vector/scalar memory response (inst) |
 | CU | `s_waitcnt` | data | S_WAITCNT waited for outstanding memory (inst) |
 | CU | `s_endpgm` | data | S_ENDPGM drained outstanding memory (inst) |
 
-A memory instruction's `inst` task ends when its last response returns; the
-`vmem`/`smem` `data` milestone lands at that moment, so the round-trip interval
-between the request leaving and the data returning is attributed rather than
-left as an unexplained gap at the end of the bar.
+A vector-memory `inst` task is tiled into three phases: `vmem-inflight` (the
+in-flight slot is acquired, at coalesce/execute) → `coalesce` (the first
+transaction is actually sent) → `vmem` `data` (the last response returns, at the
+task end). The `coalesce` milestone matters because the request is not yet
+outstanding between admission and first send, so that interval must not be
+attributed to the data wait — the `data` interval then lines up exactly with the
+child `req_out` transaction bars.
 
 Each component package has a `milestone_tracing_test.go` (or equivalent)
 asserting its milestones with a recording tracer.

--- a/amd/timing/cp/cpMiddleware.go
+++ b/amd/timing/cp/cpMiddleware.go
@@ -141,6 +141,16 @@ func (m *cpMiddleware) processLaunchKernelReq(
 		sampling.SampledEngineInstance.Reset()
 	}
 	d.StartDispatching(req)
+
+	// A dispatcher was free, so the kernel launch is admitted now. If it had to
+	// wait in the incoming buffer for a free dispatcher, this marks the
+	// resolution of that wait on the buffer task.
+	tracing.AddMilestone(m.comp, tracing.Milestone{
+		TaskID: tracing.MsgIDAtIncomingBuffer(req, m.comp),
+		Kind:   tracing.MilestoneKindHardwareResource,
+		What:   "dispatcher",
+	})
+
 	m.toDriver().RetrieveIncoming()
 
 	tracing.TraceReqReceive(m.comp, req)
@@ -217,6 +227,16 @@ func (m *cpMiddleware) processMemCopyReq(req messaging.Msg) bool {
 	}
 
 	m.toDMA().Send(cloned)
+
+	// The downstream port to the DMA engine was free, so the copy is admitted
+	// now. If it had to wait in the incoming buffer for the port to drain, this
+	// marks the resolution of that wait on the buffer task.
+	tracing.AddMilestone(m.comp, tracing.Milestone{
+		TaskID: tracing.MsgIDAtIncomingBuffer(req, m.comp),
+		Kind:   tracing.MilestoneKindNetworkBusy,
+		What:   "ToDMA",
+	})
+
 	m.toDriver().RetrieveIncoming()
 
 	tracing.TraceReqReceive(m.comp, req)

--- a/amd/timing/cp/ctrlMiddleware.go
+++ b/amd/timing/cp/ctrlMiddleware.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sarchlab/akita/v5/mem/vm"
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 	"github.com/sarchlab/mgpusim/v5/amd/protocol"
 	"github.com/sarchlab/mgpusim/v5/amd/timing/rdma"
 )
@@ -191,6 +192,10 @@ func (m *ctrlMiddleware) sendPendingDriverRsps() bool {
 		meta.Dst = state.CurrFlushReq.Src
 		meta.RspTo = state.CurrFlushReq.ID
 		m.toDriver().Send(protocol.GeneralRsp{MsgMeta: meta})
+		// Complete the req_in opened for the FlushReq in
+		// cpMiddleware.processFlushReq; otherwise it leaks (the flush is
+		// handled entirely on the control path, which opens no task of its own).
+		tracing.TraceReqComplete(m.comp, state.CurrFlushReq)
 		state.CurrFlushReq = protocol.FlushReq{}
 	case driverRspShootdownDone:
 		m.toDriver().Send(protocol.ShootDownCompleteRsp{MsgMeta: meta})

--- a/amd/timing/cp/dma.go
+++ b/amd/timing/cp/dma.go
@@ -196,6 +196,12 @@ func (m *dmaMiddleware) processDataReadyRsp(
 	copy(processing.DstBuffer[offset:], rsp.Data)
 
 	if result.isFinished() {
+		// All bottom reads have returned: mark the end of the wait for memory.
+		tracing.AddMilestone(m.comp, tracing.Milestone{
+			TaskID: tracing.MsgIDAtReceiver(processing, m.comp),
+			Kind:   tracing.MilestoneKindData,
+			What:   "ToMem",
+		})
 		tracing.TraceReqComplete(m.comp, processing)
 		m.removeReqFromProcessingReqList(processing.Meta().ID)
 
@@ -232,6 +238,12 @@ func (m *dmaMiddleware) processDoneRsp(
 
 	if result.isFinished() {
 		processing := result.getSuperior().(protocol.MemCopyH2DReq)
+		// All bottom writes have completed: mark the end of the wait for memory.
+		tracing.AddMilestone(m.comp, tracing.Milestone{
+			TaskID: tracing.MsgIDAtReceiver(processing, m.comp),
+			Kind:   tracing.MilestoneKindData,
+			What:   "ToMem",
+		})
 		tracing.TraceReqComplete(m.comp, processing)
 		m.removeReqFromProcessingReqList(processing.Meta().ID)
 
@@ -290,10 +302,21 @@ func (m *dmaMiddleware) parseFromCP() bool {
 		return false
 	}
 
-	req := m.toCP().RetrieveIncoming()
+	req := m.toCP().PeekIncoming()
 	if req == nil {
 		return false
 	}
+
+	// A processing slot was free, so this request is admitted now. If it had to
+	// wait in the incoming buffer for a slot, this marks the resolution of that
+	// wait on the buffer task (the DBTracer collapses it when there was none).
+	tracing.AddMilestone(m.comp, tracing.Milestone{
+		TaskID: tracing.MsgIDAtIncomingBuffer(req, m.comp),
+		Kind:   tracing.MilestoneKindHardwareResource,
+		What:   "processing slot",
+	})
+
+	m.toCP().RetrieveIncoming()
 	tracing.TraceReqReceive(m.comp, req)
 
 	rqC := NewRequestCollection(req)

--- a/amd/timing/cp/internal/dispatching/dispatcher.go
+++ b/amd/timing/cp/internal/dispatching/dispatcher.go
@@ -336,6 +336,12 @@ func (d *DispatcherImpl) dispatchNextWG() (madeProgress bool) {
 		d.progressBar.IncrementInProgress(1)
 	}
 
+	// The MapWGReq req_out is opened on the dispatcher domain (d), while its
+	// parent — the LaunchKernelReq req_in — lives on the Command Processor
+	// domain (d.cp). This cross-domain parent link is intentional and resolves
+	// correctly: the vis DBTracer is the same instance attached to both d (via
+	// report.go / the CP builder) and d.cp (via RegisterComponent), so both
+	// tasks land in one trace database keyed by task ID.
 	tracing.TraceReqInitiate(d, req,
 		tracing.MsgIDAtReceiver(d.dispatching, d.cp))
 

--- a/amd/timing/cp/milestone_tracing_test.go
+++ b/amd/timing/cp/milestone_tracing_test.go
@@ -1,0 +1,99 @@
+package cp
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/mgpusim/v5/amd/protocol"
+)
+
+// milestoneRecorder is a tracing.Tracer that captures the milestones a
+// component emits, so a test can assert blocked-time is being attributed.
+type milestoneRecorder struct {
+	tracing.NopTracer
+
+	milestones []tracing.Milestone
+}
+
+func (r *milestoneRecorder) AddMilestone(m tracing.Milestone) {
+	r.milestones = append(r.milestones, m)
+}
+
+func (r *milestoneRecorder) has(kind tracing.MilestoneKind, what string) bool {
+	for _, m := range r.milestones {
+		if m.Kind == kind && m.What == what {
+			return true
+		}
+	}
+
+	return false
+}
+
+// A completed memory copy must record a "data" milestone on its req_in task,
+// marking the end of the time the copy spent waiting on the memory system.
+func TestDMARecordsDataMilestoneOnMemCopyComplete(t *testing.T) {
+	const memPort = messaging.RemotePort("Mem.Top")
+
+	engine := timing.NewSerialEngine()
+	reg := modeling.NewStandaloneRegistrar(engine)
+	dma := MakeDMAEngineBuilder().
+		WithRegistrar(reg).
+		WithResources(DMAResources{
+			LocalDataSource: &mem.SinglePortMapper{Port: memPort},
+		}).
+		Build("DMA")
+
+	assign := func(name string) messaging.Port {
+		p := modeling.MakePortBuilder().
+			WithRegistrar(reg).
+			WithComponent(dma).
+			WithSpec(modeling.PortSpec{BufSize: 16}).
+			Build(name)
+		dma.AssignPort(name, p)
+		(&noopConn{}).PlugIn(p)
+		return p
+	}
+	_ = assign("ToCP")
+	toMem := assign("ToMem")
+
+	rec := &milestoneRecorder{}
+	tracing.CollectTrace(dma, rec)
+	mw := dma.Middlewares()[0].(*dmaMiddleware)
+
+	req := protocol.MemCopyD2HReq{
+		MsgMeta: messaging.MsgMeta{
+			ID: timing.GetIDGenerator().Generate(),
+		},
+		SrcAddress: 64,
+		DstBuffer:  make([]byte, 64),
+	}
+	rqC := NewRequestCollection(req)
+	mw.processingReqs = append(mw.processingReqs, rqC)
+
+	read := memprotocol.ReadReq{
+		MsgMeta:        messaging.MsgMeta{ID: timing.GetIDGenerator().Generate()},
+		Address:        64,
+		AccessByteSize: 64,
+	}
+	mw.pendingReqs = append(mw.pendingReqs, read)
+	rqC.appendSubordinateID(read.Meta().ID)
+
+	toMem.Deliver(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			RspTo: read.ID,
+		},
+		Data: make([]byte, 64),
+	})
+	mw.parseFromMem()
+
+	if !rec.has(tracing.MilestoneKindData, "ToMem") {
+		t.Fatalf("expected a data milestone on memcopy completion, got %+v",
+			rec.milestones)
+	}
+}

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -291,6 +291,7 @@ func (cu *ComputeUnit) flushPipeline() bool {
 	cu.shadowInFlightVectorMemAccess = nil
 
 	cu.populateShadowBuffers()
+	cu.endInflightTracingTasks()
 	cu.setWavesToReady()
 	cu.Scheduler.Flush()
 	cu.flushInternalComponents()
@@ -321,6 +322,35 @@ func (cu *ComputeUnit) flushInternalComponents() {
 	cu.LDSDecoder.Flush()
 	cu.VectorMemDecoder.Flush()
 	cu.VectorMemUnit.Flush()
+}
+
+// endInflightTracingTasks ends the tracing tasks that a pipeline flush drops,
+// so they do not leak as started-never-ended. A flush resets every running
+// wavefront to WfReady (setWavesToReady) and clears the sub-unit pipeline
+// stages and the scheduler's internalExecuting slice; an instruction sitting in
+// one of those stages is re-issued from scratch (with a new ID) after the
+// restart, so its "inst" task would otherwise never end. Such a wavefront is in
+// the WfRunning state, so ending the inst task of every running wavefront
+// covers all sub-unit stages and internalExecuting uniformly.
+//
+// In-flight memory accesses are not dropped: they are preserved in the shadow
+// buffers and re-sent, and their inst tasks end when the (shadowed) response
+// returns. Those wavefronts have already advanced past the issuing instruction
+// and sit in WfReady, so the WfRunning filter correctly skips them and the inst
+// task is not double-ended. The shadowed accesses' req_out tasks are ended in
+// populateShadowBuffers, where the re-send regenerates the message ID.
+func (cu *ComputeUnit) endInflightTracingTasks() {
+	for _, wfPool := range cu.WfPools {
+		for _, wf := range wfPool.wfs {
+			if wf.State != wavefront.WfRunning {
+				continue
+			}
+
+			if inst := wf.DynamicInst(); inst != nil {
+				tracing.EndTaskOnReset(cu.comp, inst.ID)
+			}
+		}
+	}
 }
 
 func (cu *ComputeUnit) processInputFromACE() bool {
@@ -388,7 +418,14 @@ func (cu *ComputeUnit) handleWfCompletionEvent(
 
 	s.resetRegisterValue(wf)
 	cu.clearWGResource(wf.WG)
-	tracing.EndTask(cu.comp, tracing.TaskEnd{ID: wf.UID})
+
+	// This path only runs for sampled wavefronts, each of which opened its own
+	// "wavefront" task in handleMapWGReq. The work-group completes as a unit
+	// here, so end every wavefront's task, not just the one whose completion
+	// event fired — otherwise the other wavefronts' tasks leak.
+	for _, wgWf := range wf.WG.Wfs {
+		tracing.EndTask(cu.comp, tracing.TaskEnd{ID: wgWf.UID})
+	}
 	tracing.TraceReqComplete(cu.comp, wf.WG.MapReq)
 }
 
@@ -886,19 +923,33 @@ func (cu *ComputeUnit) sendInstFetchShadowBufferAccesses() bool {
 }
 
 func (cu *ComputeUnit) populateShadowBuffers() {
+	// The shadowed accesses are re-sent after the restart with freshly
+	// generated message IDs (see sendOutShadowBufferReqs) and are not
+	// re-initiated, so their original req_out tasks — keyed on the old message
+	// ID — would never be finalized. End them here. EndTaskOnReset is a no-op
+	// for an access that was buffered but never sent (no req_out was opened).
 	for i := 0; i < len(cu.InFlightInstFetch); i++ {
+		tracing.EndTaskOnReset(cu.comp, cu.InFlightInstFetch[i].Req.ID)
 		cu.shadowInFlightInstFetch = append(
 			cu.shadowInFlightInstFetch, cu.InFlightInstFetch[i])
 	}
 
 	for i := 0; i < len(cu.InFlightScalarMemAccess); i++ {
+		tracing.EndTaskOnReset(cu.comp, cu.InFlightScalarMemAccess[i].Req.ID)
 		cu.shadowInFlightScalarMemAccess = append(
 			cu.shadowInFlightScalarMemAccess, cu.InFlightScalarMemAccess[i])
 	}
 
 	for i := 0; i < len(cu.InFlightVectorMemAccess); i++ {
+		info := cu.InFlightVectorMemAccess[i]
+		if info.Read != nil {
+			tracing.EndTaskOnReset(cu.comp, info.Read.ID)
+		}
+		if info.Write != nil {
+			tracing.EndTaskOnReset(cu.comp, info.Write.ID)
+		}
 		cu.shadowInFlightVectorMemAccess = append(
-			cu.shadowInFlightVectorMemAccess, cu.InFlightVectorMemAccess[i])
+			cu.shadowInFlightVectorMemAccess, info)
 	}
 
 	cu.InFlightScalarMemAccess = nil

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -885,6 +885,10 @@ func (cu *ComputeUnit) sendScalarShadowBufferAccesses() bool {
 		info.Req.ID = timing.GetIDGenerator().Generate()
 		if cu.scalarMemPort().CanSend() {
 			cu.scalarMemPort().Send(info.Req)
+			// The resend has a fresh message ID; open a replacement req_out
+			// task (the original was ended in populateShadowBuffers) so the
+			// post-flush round trip is traced and TraceReqFinalize matches.
+			tracing.TraceReqInitiate(cu.comp, info.Req, info.Inst.ID)
 			cu.InFlightScalarMemAccess =
 				append(cu.InFlightScalarMemAccess, info)
 			cu.shadowInFlightScalarMemAccess =
@@ -903,6 +907,7 @@ func (cu *ComputeUnit) sendVectorShadowBufferAccesses() bool {
 			info.Read.ID = timing.GetIDGenerator().Generate()
 			if cu.vectorMemPort().CanSend() {
 				cu.vectorMemPort().Send(*info.Read)
+				tracing.TraceReqInitiate(cu.comp, *info.Read, info.Inst.ID)
 				cu.InFlightVectorMemAccess = append(
 					cu.InFlightVectorMemAccess, info)
 				cu.shadowInFlightVectorMemAccess =
@@ -913,6 +918,7 @@ func (cu *ComputeUnit) sendVectorShadowBufferAccesses() bool {
 			info.Write.ID = timing.GetIDGenerator().Generate()
 			if cu.vectorMemPort().CanSend() {
 				cu.vectorMemPort().Send(*info.Write)
+				tracing.TraceReqInitiate(cu.comp, *info.Write, info.Inst.ID)
 				cu.InFlightVectorMemAccess = append(
 					cu.InFlightVectorMemAccess, info)
 				cu.shadowInFlightVectorMemAccess =
@@ -930,6 +936,7 @@ func (cu *ComputeUnit) sendInstFetchShadowBufferAccesses() bool {
 		info.Req.ID = timing.GetIDGenerator().Generate()
 		if cu.instMemPort().CanSend() {
 			cu.instMemPort().Send(info.Req)
+			tracing.TraceReqInitiate(cu.comp, info.Req, info.FetchTaskID)
 			cu.InFlightInstFetch = append(cu.InFlightInstFetch, info)
 			cu.shadowInFlightInstFetch = cu.shadowInFlightInstFetch[1:]
 			return true
@@ -940,10 +947,11 @@ func (cu *ComputeUnit) sendInstFetchShadowBufferAccesses() bool {
 
 func (cu *ComputeUnit) populateShadowBuffers() {
 	// The shadowed accesses are re-sent after the restart with freshly
-	// generated message IDs (see sendOutShadowBufferReqs) and are not
-	// re-initiated, so their original req_out tasks — keyed on the old message
-	// ID — would never be finalized. End them here. EndTaskOnReset is a no-op
-	// for an access that was buffered but never sent (no req_out was opened).
+	// generated message IDs (see sendOutShadowBufferReqs), and the resend opens
+	// a fresh req_out task for the new ID. End the original req_out tasks —
+	// keyed on the old message ID — here, so they are not left unfinalized
+	// across the flush. EndTaskOnReset is a no-op for an access that was
+	// buffered but never sent (no req_out was opened).
 	for i := 0; i < len(cu.InFlightInstFetch); i++ {
 		tracing.EndTaskOnReset(cu.comp, cu.InFlightInstFetch[i].Req.ID)
 		cu.shadowInFlightInstFetch = append(

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -633,6 +633,13 @@ func (cu *ComputeUnit) handleScalarDataLoadReturn(
 
 	if cu.isLastRead(req) {
 		wf.OutstandingScalarMemAccess--
+	}
+
+	// Coalesced responses can return out of order, so isLastRead (the last
+	// request generated) is not necessarily the last received. End the inst
+	// task and mark the data wait only once no access for this instruction is
+	// still in flight.
+	if !cu.hasInFlightScalarMemFor(info.Inst) {
 		cu.markInstDataReturned(info.Inst, "smem")
 		cu.logInstTask(wf, info.Inst, true)
 	}
@@ -653,6 +660,30 @@ func (cu *ComputeUnit) markInstDataReturned(inst *wavefront.Inst, what string) {
 		Kind:   tracing.MilestoneKindData,
 		What:   what,
 	})
+}
+
+// hasInFlightVectorMemFor reports whether any vector-memory transaction for the
+// given instruction is still in flight.
+func (cu *ComputeUnit) hasInFlightVectorMemFor(inst *wavefront.Inst) bool {
+	for _, info := range cu.InFlightVectorMemAccess {
+		if info.Inst == inst {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasInFlightScalarMemFor reports whether any scalar-memory access for the given
+// instruction is still in flight.
+func (cu *ComputeUnit) hasInFlightScalarMemFor(inst *wavefront.Inst) bool {
+	for _, info := range cu.InFlightScalarMemAccess {
+		if info.Inst == inst {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (cu *ComputeUnit) processInputFromVectorMem() bool {
@@ -730,7 +761,13 @@ func (cu *ComputeUnit) handleVectorDataLoadReturn(
 		if info.Inst.FormatType == insts.FLAT {
 			wf.OutstandingScalarMemAccess--
 		}
+	}
 
+	// Coalesced responses can return out of order, so CanWaitForCoalesce (the
+	// last request generated) is not necessarily the last received. End the
+	// inst task and mark the data wait only once no transaction for this
+	// instruction is still in flight.
+	if !cu.hasInFlightVectorMemFor(info.Inst) {
 		cu.markInstDataReturned(info.Inst, "vmem")
 		cu.logInstTask(wf, info.Inst, true)
 	}
@@ -762,6 +799,12 @@ func (cu *ComputeUnit) handleVectorDataStoreRsp(
 		if info.Inst.FormatType == insts.FLAT {
 			wf.OutstandingScalarMemAccess--
 		}
+	}
+
+	// Coalesced responses can return out of order; end the inst task and mark
+	// the data wait only once no transaction for this instruction remains in
+	// flight (see handleVectorDataLoadReturn).
+	if !cu.hasInFlightVectorMemFor(info.Inst) {
 		cu.markInstDataReturned(info.Inst, "vmem")
 		cu.logInstTask(wf, info.Inst, true)
 	}

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -663,9 +663,16 @@ func (cu *ComputeUnit) markInstDataReturned(inst *wavefront.Inst, what string) {
 }
 
 // hasInFlightVectorMemFor reports whether any vector-memory transaction for the
-// given instruction is still in flight.
+// given instruction is still in flight — including siblings parked in the
+// shadow buffer during a flush resend but not yet re-sent.
 func (cu *ComputeUnit) hasInFlightVectorMemFor(inst *wavefront.Inst) bool {
 	for _, info := range cu.InFlightVectorMemAccess {
+		if info.Inst == inst {
+			return true
+		}
+	}
+
+	for _, info := range cu.shadowInFlightVectorMemAccess {
 		if info.Inst == inst {
 			return true
 		}
@@ -675,9 +682,16 @@ func (cu *ComputeUnit) hasInFlightVectorMemFor(inst *wavefront.Inst) bool {
 }
 
 // hasInFlightScalarMemFor reports whether any scalar-memory access for the given
-// instruction is still in flight.
+// instruction is still in flight — including shadow-buffered siblings that have
+// not been re-sent yet.
 func (cu *ComputeUnit) hasInFlightScalarMemFor(inst *wavefront.Inst) bool {
 	for _, info := range cu.InFlightScalarMemAccess {
+		if info.Inst == inst {
+			return true
+		}
+	}
+
+	for _, info := range cu.shadowInFlightScalarMemAccess {
 		if info.Inst == inst {
 			return true
 		}

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -633,12 +633,26 @@ func (cu *ComputeUnit) handleScalarDataLoadReturn(
 
 	if cu.isLastRead(req) {
 		wf.OutstandingScalarMemAccess--
+		cu.markInstDataReturned(info.Inst, "smem")
 		cu.logInstTask(wf, info.Inst, true)
 	}
 }
 
 func (cu *ComputeUnit) isLastRead(req memprotocol.ReadReq) bool {
 	return !req.CanWaitForCoalesce
+}
+
+// markInstDataReturned records a "data" milestone on a memory instruction's
+// task when its last memory response returns. The instruction's task ends at
+// that same moment, so this closes the otherwise-unattributed gap between the
+// memory request going out (or the in-flight slot being acquired) and the data
+// coming back.
+func (cu *ComputeUnit) markInstDataReturned(inst *wavefront.Inst, what string) {
+	tracing.AddMilestone(cu.comp, tracing.Milestone{
+		TaskID: inst.ID,
+		Kind:   tracing.MilestoneKindData,
+		What:   what,
+	})
 }
 
 func (cu *ComputeUnit) processInputFromVectorMem() bool {
@@ -717,6 +731,7 @@ func (cu *ComputeUnit) handleVectorDataLoadReturn(
 			wf.OutstandingScalarMemAccess--
 		}
 
+		cu.markInstDataReturned(info.Inst, "vmem")
 		cu.logInstTask(wf, info.Inst, true)
 	}
 }
@@ -747,6 +762,7 @@ func (cu *ComputeUnit) handleVectorDataStoreRsp(
 		if info.Inst.FormatType == insts.FLAT {
 			wf.OutstandingScalarMemAccess--
 		}
+		cu.markInstDataReturned(info.Inst, "vmem")
 		cu.logInstTask(wf, info.Inst, true)
 	}
 }

--- a/amd/timing/cu/computeunit_test.go
+++ b/amd/timing/cu/computeunit_test.go
@@ -604,14 +604,21 @@ var _ = Describe("ComputeUnit", func() {
 			cu.shadowInFlightInstFetch = append(
 				cu.shadowInFlightInstFetch, info)
 
+			// Mem accesses always carry their instruction in production (set
+			// in executeSMEMLoad / the coalescer); the shadow resend parents
+			// the replacement req_out task on it.
+			inst := wavefront.NewInst(insts.NewInst())
+
 			scalarMemInfo := new(ScalarMemAccessInfo)
 			scalarMemInfo.Req = req
+			scalarMemInfo.Inst = inst
 			cu.shadowInFlightScalarMemAccess = append(
 				cu.shadowInFlightScalarMemAccess, scalarMemInfo)
 
 			vectorMemInfo := VectorMemAccessInfo{}
 			readCopy := req
 			vectorMemInfo.Read = &readCopy
+			vectorMemInfo.Inst = inst
 			cu.shadowInFlightVectorMemAccess = append(
 				cu.shadowInFlightVectorMemAccess, vectorMemInfo)
 

--- a/amd/timing/cu/flush_tracing_test.go
+++ b/amd/timing/cu/flush_tracing_test.go
@@ -100,6 +100,41 @@ func TestPopulateShadowBuffersEndsReqOutTasks(t *testing.T) {
 	}
 }
 
+// The shadow resend assigns a fresh message ID, so it must open a replacement
+// req_out task (the original was ended in populateShadowBuffers); otherwise the
+// post-flush memory round trip has no task and TraceReqFinalize finds nothing.
+func TestShadowResendOpensReplacementReqOut(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	cu.ToInstMem = newFakePort("CU.ToInstMem")
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	cu.shadowInFlightInstFetch = []*InstFetchReqInfo{
+		{
+			Req: memprotocol.ReadReq{
+				MsgMeta: messaging.MsgMeta{
+					ID: timing.GetIDGenerator().Generate(),
+				},
+			},
+			FetchTaskID: timing.GetIDGenerator().Generate(),
+		},
+	}
+
+	cu.sendInstFetchShadowBufferAccesses()
+
+	resentID := cu.InFlightInstFetch[0].Req.ID
+	found := false
+	for _, open := range rec.OpenTasks() {
+		if open.Kind == tracing.ReqOutTaskKind && open.ID == resentID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("shadow resend should open a req_out task for the resent "+
+			"fetch; open=%s", rec.OpenSummary())
+	}
+}
+
 // The per-SIMD "pipeline" tasks live on the SIMD-unit tracing domain (so the
 // per-SIMD busy-time tracer can measure them). A flush drops the instructions
 // in the SIMD pipeline, so those pipeline tasks must be ended too.

--- a/amd/timing/cu/flush_tracing_test.go
+++ b/amd/timing/cu/flush_tracing_test.go
@@ -1,0 +1,128 @@
+package cu
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/akita/v5/tracing/tracingtest"
+	"github.com/sarchlab/mgpusim/v5/amd/insts"
+	"github.com/sarchlab/mgpusim/v5/amd/kernels"
+	"github.com/sarchlab/mgpusim/v5/amd/timing/wavefront"
+)
+
+// A pipeline flush drops the instructions sitting in the sub-unit pipeline
+// stages and the scheduler's internalExecuting slice; those wavefronts are in
+// WfRunning and re-issue fresh after the restart, so their "inst" tasks must be
+// ended on flush or they leak.
+func TestEndInflightTracingTasksEndsRunningInstTasks(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	pool := NewWavefrontPool(4)
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	inst := wavefront.NewInst(insts.NewInst())
+	inst.ExeUnit = insts.ExeUnitVALU
+	wf.SetDynamicInst(inst)
+	wf.State = wavefront.WfRunning
+	pool.AddWf(wf)
+	cu.WfPools = []*WavefrontPool{pool}
+
+	cu.logInstTask(wf, inst, false)
+	if rec.NumStarted() != 1 {
+		t.Fatalf("expected the inst task to be started, got %d", rec.NumStarted())
+	}
+
+	cu.endInflightTracingTasks()
+
+	if got := rec.OpenSummary(); got != "none" {
+		t.Fatalf("flush leaked tracing tasks: %s", got)
+	}
+}
+
+// A WfReady wavefront (e.g. one whose memory access is in flight and preserved
+// in the shadow buffer) must be left alone — its inst task is ended when the
+// shadowed response returns, so the flush sweep must not end it.
+func TestEndInflightTracingTasksSkipsNonRunningWavefronts(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	pool := NewWavefrontPool(4)
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	inst := wavefront.NewInst(insts.NewInst())
+	inst.ExeUnit = insts.ExeUnitVMem
+	wf.SetDynamicInst(inst)
+	wf.State = wavefront.WfReady
+	pool.AddWf(wf)
+	cu.WfPools = []*WavefrontPool{pool}
+
+	cu.logInstTask(wf, inst, false)
+
+	cu.endInflightTracingTasks()
+
+	if len(rec.OpenTasks()) != 1 {
+		t.Fatalf("the WfReady wavefront's inst task should stay open, got %s",
+			rec.OpenSummary())
+	}
+}
+
+// In-flight memory accesses are re-sent from the shadow buffers with freshly
+// generated message IDs, so their original req_out tasks would never be
+// finalized. populateShadowBuffers must end them.
+func TestPopulateShadowBuffersEndsReqOutTasks(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	fetchTaskID := timing.GetIDGenerator().Generate()
+	tracing.StartTask(cu.comp, tracing.TaskStart{
+		ID: fetchTaskID, Kind: "fetch", What: "fetch",
+	})
+	req := memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{ID: timing.GetIDGenerator().Generate()},
+	}
+	tracing.TraceReqInitiate(cu.comp, req, fetchTaskID)
+
+	cu.InFlightInstFetch = []*InstFetchReqInfo{
+		{Req: req, FetchTaskID: fetchTaskID},
+	}
+
+	cu.populateShadowBuffers()
+
+	for _, open := range rec.OpenTasks() {
+		if open.Kind == tracing.ReqOutTaskKind {
+			t.Fatalf("populateShadowBuffers leaked a req_out task")
+		}
+	}
+}
+
+// The per-SIMD "pipeline" tasks live on the SIMD-unit tracing domain (so the
+// per-SIMD busy-time tracer can measure them). A flush drops the instructions
+// in the SIMD pipeline, so those pipeline tasks must be ended too.
+func TestSIMDFlushEndsPipelineTasks(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	simd := NewSIMDUnit(cu, "CU.SIMD", new(mockALU))
+	rec := &tracingtest.LeakRecorder{}
+	tracing.CollectTrace(simd, rec)
+
+	wave := wavefront.NewWavefront(kernels.NewWavefront())
+	inst := wavefront.NewInst(insts.NewInst())
+	inst.ExeUnit = insts.ExeUnitVALU
+	wave.SetDynamicInst(inst)
+
+	simd.AcceptWave(wave)
+	if rec.NumStarted() != 1 {
+		t.Fatalf("expected the pipeline task to be started, got %d",
+			rec.NumStarted())
+	}
+
+	simd.Flush()
+
+	if got := rec.OpenSummary(); got != "none" {
+		t.Fatalf("SIMD flush leaked tracing tasks: %s", got)
+	}
+}

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sarchlab/akita/v5/mem/memprotocol"
 	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/queueing"
 	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 	"github.com/sarchlab/mgpusim/v5/amd/insts"
@@ -90,6 +91,40 @@ func TestVectorMemDataReturnRecordsDataMilestone(t *testing.T) {
 
 	if !rec.has(inst.ID, tracing.MilestoneKindData, "vmem") {
 		t.Fatalf("expected a data milestone for the vmem return, got %+v",
+			rec.milestones)
+	}
+}
+
+// When a vector-memory transaction is sent, the CU must record a "coalesce"
+// milestone on the instruction's task, so the data wait is attributed only
+// from the moment a request is actually outstanding — not from the earlier
+// in-flight admission, which would mislabel the coalescing/issue phase.
+func TestVectorMemSendRecordsCoalesceMilestone(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	cu.ToVectorMem = newFakePort("CU.ToVectorMem")
+	vmu := NewVectorMemoryUnit(cu, nil)
+	vmu.postTransactionPipelineBuffer =
+		queueing.NewBuffer[VectorMemAccessInfo]("CU.PostTransBuf", 8)
+
+	inst := wavefront.NewInst(nil)
+	read := &memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{
+			ID:  timing.GetIDGenerator().Generate(),
+			Src: cu.ToVectorMem.AsRemote(),
+			Dst: "VectorMem",
+		},
+	}
+	vmu.numTransactionInFlight = 1
+	vmu.postTransactionPipelineBuffer.PushTyped(
+		VectorMemAccessInfo{Read: read, Inst: inst})
+
+	vmu.sendRequest()
+
+	if !rec.has(inst.ID, tracing.MilestoneKindHardwareResource, "coalesce") {
+		t.Fatalf("expected a coalesce milestone on transaction send, got %+v",
 			rec.milestones)
 	}
 }

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -3,6 +3,9 @@ package cu
 import (
 	"testing"
 
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 	"github.com/sarchlab/mgpusim/v5/amd/insts"
 	"github.com/sarchlab/mgpusim/v5/amd/kernels"
@@ -54,6 +57,39 @@ func TestSWaitCntRecordsDataMilestone(t *testing.T) {
 	}
 	if !rec.has(inst.ID, tracing.MilestoneKindData, "s_waitcnt") {
 		t.Fatalf("expected a data milestone for s_waitcnt, got %+v",
+			rec.milestones)
+	}
+}
+
+// When a vector-memory load's last response returns, the CU must record a
+// "data" milestone on the instruction's task so its lifetime is fully
+// attributed — without it the bar shows an unexplained gap between the
+// in-flight admission and the task end (the memory round trip).
+func TestVectorMemDataReturnRecordsDataMilestone(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	inst := wavefront.NewInst(insts.NewInst())
+	inst.ExeUnit = insts.ExeUnitVMem
+	wf.SetDynamicInst(inst)
+
+	read := memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{ID: timing.GetIDGenerator().Generate()},
+	}
+	cu.InFlightVectorMemAccess = append(cu.InFlightVectorMemAccess,
+		VectorMemAccessInfo{Read: &read, Inst: inst, Wavefront: wf})
+
+	cu.handleVectorDataLoadReturn(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			RspTo: read.ID,
+		},
+	})
+
+	if !rec.has(inst.ID, tracing.MilestoneKindData, "vmem") {
+		t.Fatalf("expected a data milestone for the vmem return, got %+v",
 			rec.milestones)
 	}
 }

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -117,6 +117,68 @@ func TestSEndPgmMilestoneEmittedOnceNotOnAceRetry(t *testing.T) {
 	}
 }
 
+// orderedEndRecorder records, in order, the s_endpgm milestone and the end of a
+// specific task, so a test can assert the milestone is emitted before the task
+// is closed.
+type orderedEndRecorder struct {
+	tracing.NopTracer
+
+	instID uint64
+	events []string
+}
+
+func (r *orderedEndRecorder) AddMilestone(m tracing.Milestone) {
+	if m.TaskID == r.instID && m.What == "s_endpgm" {
+		r.events = append(r.events, "milestone")
+	}
+}
+
+func (r *orderedEndRecorder) EndTask(e tracing.TaskEnd) {
+	if e.ID == r.instID {
+		r.events = append(r.events, "endTask")
+	}
+}
+
+// When S_ENDPGM retires while other wavefronts are still executing, the branch
+// closes the inst task via logInstTask. The s_endpgm milestone must be emitted
+// before that, so it attributes the instruction's lifetime rather than landing
+// on an already-ended task.
+func TestSEndPgmMilestoneEmittedBeforeInstTaskEnds(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	cu.WfPools = []*WavefrontPool{NewWavefrontPool(10)}
+	s := NewScheduler(cu, nil, nil)
+
+	wg := new(wavefront.WorkGroup)
+	co := &insts.KernelCodeObject{
+		KernelCodeObjectMeta: &insts.KernelCodeObjectMeta{},
+	}
+
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	wf.CodeObject = co
+	wf.SetDynamicInst(wavefront.NewInst(insts.NewInst()))
+	wf.WG = wg
+	wf.State = wavefront.WfRunning
+
+	other := wavefront.NewWavefront(kernels.NewWavefront())
+	other.CodeObject = co
+	other.WG = wg
+	other.State = wavefront.WfRunning // still executing -> the "executing" branch
+	wg.Wfs = []*wavefront.Wavefront{wf, other}
+
+	rec := &orderedEndRecorder{instID: wf.DynamicInst().ID}
+	tracing.CollectTrace(cu.comp, rec)
+
+	if _, completed := s.evalSEndPgm(wf); !completed {
+		t.Fatal("S_ENDPGM should retire on the executing branch")
+	}
+
+	if len(rec.events) != 2 ||
+		rec.events[0] != "milestone" || rec.events[1] != "endTask" {
+		t.Fatalf("s_endpgm milestone must be emitted before the inst task "+
+			"ends; got %v", rec.events)
+	}
+}
+
 // When a vector-memory load's last response returns, the CU must record a
 // "data" milestone on the instruction's task so its lifetime is fully
 // attributed — without it the bar shows an unexplained gap between the

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sarchlab/akita/v5/tracing"
 	"github.com/sarchlab/mgpusim/v5/amd/insts"
 	"github.com/sarchlab/mgpusim/v5/amd/kernels"
+	"github.com/sarchlab/mgpusim/v5/amd/protocol"
 	"github.com/sarchlab/mgpusim/v5/amd/timing/wavefront"
 )
 
@@ -59,6 +60,60 @@ func TestSWaitCntRecordsDataMilestone(t *testing.T) {
 	if !rec.has(inst.ID, tracing.MilestoneKindData, "s_waitcnt") {
 		t.Fatalf("expected a data milestone for s_waitcnt, got %+v",
 			rec.milestones)
+	}
+}
+
+// The s_endpgm milestone must be emitted exactly once. If S_ENDPGM is the last
+// wavefront in the work-group and the ACE port is full, the wavefront stays
+// pending and re-enters evalSEndPgm next tick; the milestone must not be
+// emitted on that retry, only when the instruction actually retires.
+func TestSEndPgmMilestoneEmittedOnceNotOnAceRetry(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	cu.WfPools = []*WavefrontPool{NewWavefrontPool(10)}
+	ace := newFakePort("CU.ToACE")
+	cu.ToACE = ace
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+	s := NewScheduler(cu, nil, nil)
+
+	wg := new(wavefront.WorkGroup)
+	wg.MapReq = protocol.MapWGReq{
+		MsgMeta: messaging.MsgMeta{ID: timing.GetIDGenerator().Generate()},
+	}
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	wf.CodeObject = &insts.KernelCodeObject{
+		KernelCodeObjectMeta: &insts.KernelCodeObjectMeta{},
+	}
+	wf.SetDynamicInst(wavefront.NewInst(insts.NewInst()))
+	wf.WG = wg
+	wf.State = wavefront.WfRunning
+	wg.Wfs = []*wavefront.Wavefront{wf}
+	cu.WfPools[0].wfs = append(cu.WfPools[0].wfs, wf)
+	taskID := wf.DynamicInst().ID
+
+	// ACE port full: cannot send the WGCompletion, so the wavefront stays
+	// pending. The drain milestone must not be emitted on this retry path.
+	ace.full = true
+	if _, completed := s.evalSEndPgm(wf); completed {
+		t.Fatal("S_ENDPGM should not complete while the ACE port is full")
+	}
+	if rec.has(taskID, tracing.MilestoneKindData, "s_endpgm") {
+		t.Fatal("s_endpgm milestone must not be emitted on the ACE-full retry")
+	}
+
+	// ACE port free: the wavefront retires and the milestone is emitted once.
+	ace.full = false
+	s.evalSEndPgm(wf)
+
+	count := 0
+	for _, m := range rec.milestones {
+		if m.TaskID == taskID && m.Kind == tracing.MilestoneKindData &&
+			m.What == "s_endpgm" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one s_endpgm milestone, got %d", count)
 	}
 }
 

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -95,11 +95,12 @@ func TestVectorMemDataReturnRecordsDataMilestone(t *testing.T) {
 	}
 }
 
-// When a vector-memory transaction is sent, the CU must record a "coalesce"
-// milestone on the instruction's task, so the data wait is attributed only
-// from the moment a request is actually outstanding — not from the earlier
-// in-flight admission, which would mislabel the coalescing/issue phase.
-func TestVectorMemSendRecordsCoalesceMilestone(t *testing.T) {
+// Sending the first vector-memory transaction closes the issue subtask and
+// records a "work" milestone (not a hardware_resource one): the coalescing /
+// transaction-issue phase is the unit doing work, and it is backed by the
+// pipeline subtask opened at admission. The data wait is attributed only from
+// this point, once a request is actually outstanding.
+func TestVectorMemSendRecordsCoalesceWorkMilestone(t *testing.T) {
 	cu := newTestComputeUnit("CU", newFakeEngine())
 	rec := &cuMilestoneRecorder{}
 	tracing.CollectTrace(cu.comp, rec)
@@ -110,6 +111,8 @@ func TestVectorMemSendRecordsCoalesceMilestone(t *testing.T) {
 		queueing.NewBuffer[VectorMemAccessInfo]("CU.PostTransBuf", 8)
 
 	inst := wavefront.NewInst(nil)
+	vmu.startIssueSubtask(inst) // as the in-flight admission would
+
 	read := &memprotocol.ReadReq{
 		MsgMeta: messaging.MsgMeta{
 			ID:  timing.GetIDGenerator().Generate(),
@@ -123,8 +126,11 @@ func TestVectorMemSendRecordsCoalesceMilestone(t *testing.T) {
 
 	vmu.sendRequest()
 
-	if !rec.has(inst.ID, tracing.MilestoneKindHardwareResource, "coalesce") {
-		t.Fatalf("expected a coalesce milestone on transaction send, got %+v",
+	if !rec.has(inst.ID, tracing.MilestoneKindWork, "coalesce") {
+		t.Fatalf("expected a work milestone at transaction send, got %+v",
 			rec.milestones)
+	}
+	if _, ok := vmu.issueTaskIDs[inst.ID]; ok {
+		t.Fatal("the issue subtask should be closed after the first send")
 	}
 }

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -251,3 +251,69 @@ func TestVectorMemSendRecordsCoalesceWorkMilestone(t *testing.T) {
 		t.Fatal("the issue subtask should be closed after the first send")
 	}
 }
+
+func countCoalesceWork(rec *cuMilestoneRecorder, instID uint64) int {
+	count := 0
+	for _, m := range rec.milestones {
+		if m.TaskID == instID && m.Kind == tracing.MilestoneKindWork &&
+			m.What == "coalesce" {
+			count++
+		}
+	}
+
+	return count
+}
+
+// Port backpressure must not be counted as coalescing work. When the vector
+// memory port is full, the transaction is ready but cannot be sent; the
+// coalesce work milestone must still be emitted now (the work is done) and must
+// not be re-emitted when the port frees and the transaction is finally sent.
+func TestVectorMemCoalesceWorkNotDelayedByPortBackpressure(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	port := newFakePort("CU.ToVectorMem")
+	cu.ToVectorMem = port
+	vmu := NewVectorMemoryUnit(cu, nil)
+	vmu.postTransactionPipelineBuffer =
+		queueing.NewBuffer[VectorMemAccessInfo]("CU.PostTransBuf", 8)
+
+	inst := wavefront.NewInst(nil)
+	vmu.startIssueSubtask(inst)
+	read := &memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{
+			ID:  timing.GetIDGenerator().Generate(),
+			Src: cu.ToVectorMem.AsRemote(),
+			Dst: "VectorMem",
+		},
+	}
+	vmu.numTransactionInFlight = 1
+	vmu.postTransactionPipelineBuffer.PushTyped(
+		VectorMemAccessInfo{Read: read, Inst: inst})
+
+	// Port full: the transaction is ready but cannot be sent. The work
+	// milestone fires now; the transaction stays unsent.
+	port.full = true
+	vmu.sendRequest()
+
+	if got := countCoalesceWork(rec, inst.ID); got != 1 {
+		t.Fatalf("coalesce work must be emitted when ready even if the port is "+
+			"full; got %d", got)
+	}
+	if len(port.sent) != 0 {
+		t.Fatal("the transaction must not be sent while the port is full")
+	}
+
+	// Port frees: the transaction is sent, but no second work milestone.
+	port.full = false
+	vmu.sendRequest()
+
+	if got := countCoalesceWork(rec, inst.ID); got != 1 {
+		t.Fatalf("coalesce work must not be re-emitted on the actual send; "+
+			"got %d", got)
+	}
+	if len(port.sent) != 1 {
+		t.Fatal("the transaction should be sent once the port frees")
+	}
+}

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -1,0 +1,59 @@
+package cu
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/tracing"
+	"github.com/sarchlab/mgpusim/v5/amd/insts"
+	"github.com/sarchlab/mgpusim/v5/amd/kernels"
+	"github.com/sarchlab/mgpusim/v5/amd/timing/wavefront"
+)
+
+type cuMilestoneRecorder struct {
+	tracing.NopTracer
+
+	milestones []tracing.Milestone
+}
+
+func (r *cuMilestoneRecorder) AddMilestone(m tracing.Milestone) {
+	r.milestones = append(r.milestones, m)
+}
+
+func (r *cuMilestoneRecorder) has(
+	taskID uint64, kind tracing.MilestoneKind, what string,
+) bool {
+	for _, m := range r.milestones {
+		if m.TaskID == taskID && m.Kind == kind && m.What == what {
+			return true
+		}
+	}
+
+	return false
+}
+
+// When an S_WAITCNT's outstanding memory accesses have drained, the scheduler
+// must record a "data" milestone on the instruction's task, attributing the
+// time the wavefront spent waiting for memory.
+func TestSWaitCntRecordsDataMilestone(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+	s := NewScheduler(cu, nil, nil)
+
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	inst := wavefront.NewInst(insts.NewInst())
+	wf.SetDynamicInst(inst)
+	// Outstanding counts (0) already satisfy the requested counts (0), so the
+	// wait resolves immediately.
+
+	madeProgress, completed := s.evalSWaitCnt(wf)
+
+	if !madeProgress || !completed {
+		t.Fatalf("expected S_WAITCNT to retire, got progress=%v completed=%v",
+			madeProgress, completed)
+	}
+	if !rec.has(inst.ID, tracing.MilestoneKindData, "s_waitcnt") {
+		t.Fatalf("expected a data milestone for s_waitcnt, got %+v",
+			rec.milestones)
+	}
+}

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -348,3 +348,64 @@ func TestVectorMemFlushPreservesCoalesceWork(t *testing.T) {
 		t.Fatal("the issue subtask should be cleared on flush")
 	}
 }
+
+func countVMemData(rec *cuMilestoneRecorder, instID uint64) int {
+	count := 0
+	for _, m := range rec.milestones {
+		if m.TaskID == instID && m.Kind == tracing.MilestoneKindData &&
+			m.What == "vmem" {
+			count++
+		}
+	}
+
+	return count
+}
+
+// Coalesced responses can return out of order: the last request generated
+// (CanWaitForCoalesce==false) may return before its siblings. The vmem data
+// milestone must wait for the actual last response, gated on no remaining
+// in-flight transactions for the instruction.
+func TestVectorMemDataMilestoneWaitsForLastResponse(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	inst := wavefront.NewInst(insts.NewInst())
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+
+	readSibling := &memprotocol.ReadReq{
+		MsgMeta:            messaging.MsgMeta{ID: timing.GetIDGenerator().Generate()},
+		CanWaitForCoalesce: true,
+	}
+	readLastGenerated := &memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{ID: timing.GetIDGenerator().Generate()},
+	}
+	cu.InFlightVectorMemAccess = []VectorMemAccessInfo{
+		{Read: readSibling, Inst: inst, Wavefront: wf},
+		{Read: readLastGenerated, Inst: inst, Wavefront: wf},
+	}
+
+	// The last-generated transaction returns first (out of order); its sibling
+	// is still in flight, so no data milestone yet.
+	cu.handleVectorDataLoadReturn(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			RspTo: readLastGenerated.ID,
+		},
+	})
+	if countVMemData(rec, inst.ID) != 0 {
+		t.Fatal("data milestone must not fire while a sibling is still in flight")
+	}
+
+	// The actual last response returns: the milestone fires exactly once.
+	cu.handleVectorDataLoadReturn(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			RspTo: readSibling.ID,
+		},
+	})
+	if got := countVMemData(rec, inst.ID); got != 1 {
+		t.Fatalf("expected one data milestone after the last response; got %d",
+			got)
+	}
+}

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -409,3 +409,41 @@ func TestVectorMemDataMilestoneWaitsForLastResponse(t *testing.T) {
 			got)
 	}
 }
+
+// During a flush resend, coalesced siblings that have not been re-sent yet live
+// in the shadow buffer. The data milestone must not fire while such a sibling
+// is still parked there.
+func TestVectorMemDataMilestoneWaitsForShadowSiblings(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	inst := wavefront.NewInst(insts.NewInst())
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+
+	resent := &memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{ID: timing.GetIDGenerator().Generate()},
+	}
+	cu.InFlightVectorMemAccess = []VectorMemAccessInfo{
+		{Read: resent, Inst: inst, Wavefront: wf},
+	}
+	// A coalesced sibling still parked in the shadow buffer, not yet re-sent.
+	shadowSibling := &memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{ID: timing.GetIDGenerator().Generate()},
+	}
+	cu.shadowInFlightVectorMemAccess = []VectorMemAccessInfo{
+		{Read: shadowSibling, Inst: inst, Wavefront: wf},
+	}
+
+	cu.handleVectorDataLoadReturn(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			RspTo: resent.ID,
+		},
+	})
+
+	if countVMemData(rec, inst.ID) != 0 {
+		t.Fatal("data milestone must not fire while a sibling is parked in the " +
+			"shadow buffer")
+	}
+}

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -317,3 +317,34 @@ func TestVectorMemCoalesceWorkNotDelayedByPortBackpressure(t *testing.T) {
 		t.Fatal("the transaction should be sent once the port frees")
 	}
 }
+
+// A vector-memory instruction flushed after admission but before its first send
+// must keep its coalesce work milestone. Its parent inst task survives the
+// flush (for the shadow response) and the resend bypasses the unit, so Flush
+// itself must emit the milestone and end the subtask.
+func TestVectorMemFlushPreservesCoalesceWork(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	vmu := NewVectorMemoryUnit(cu, nil)
+	vmu.instructionPipeline = queueing.NewPipeline[vectorMemInst](1, 6)
+	vmu.postInstructionPipelineBuffer =
+		queueing.NewBuffer[vectorMemInst]("CU.PostInstBuf", 16)
+	vmu.transactionPipeline = queueing.NewPipeline[VectorMemAccessInfo](2, 10)
+	vmu.postTransactionPipelineBuffer =
+		queueing.NewBuffer[VectorMemAccessInfo]("CU.PostTransBuf", 8)
+
+	inst := wavefront.NewInst(nil)
+	vmu.startIssueSubtask(inst) // admitted; issue work not yet done
+
+	vmu.Flush()
+
+	if got := countCoalesceWork(rec, inst.ID); got != 1 {
+		t.Fatalf("flush must preserve the coalesce work milestone for an "+
+			"in-issue instruction; got %d", got)
+	}
+	if _, ok := vmu.issueTaskIDs[inst.ID]; ok {
+		t.Fatal("the issue subtask should be cleared on flush")
+	}
+}

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -319,10 +319,6 @@ func (s *SchedulerImpl) evalSEndPgm(
 		return false, false
 	}
 
-	// The wavefront's outstanding memory accesses have all returned, so
-	// S_ENDPGM can retire: mark the end of that drain wait.
-	s.markMemDrained(wf, "s_endpgm")
-
 	// sampling
 	now := s.cu.CurrentTime()
 	if *sampling.SampledRunnerFlag {
@@ -334,6 +330,7 @@ func (s *SchedulerImpl) evalSEndPgm(
 			delete(s.cu.wftime, wf.UID)
 		}
 	}
+
 	if s.areAllOtherWfsInWGCompleted(wf.WG, wf) {
 		done := s.sendWGCompletionMessage(wf.WG)
 		if !done {
@@ -347,33 +344,30 @@ func (s *SchedulerImpl) evalSEndPgm(
 
 		tracing.EndTask(s.cu.comp, tracing.TaskEnd{ID: wf.UID})
 		tracing.TraceReqComplete(s.cu.comp, wf.WG.MapReq)
-
-		return true, true
-	}
-
-	if s.areAllOtherWfsInWGAtBarrier(wf.WG, wf) {
+	} else if s.areAllOtherWfsInWGAtBarrier(wf.WG, wf) {
 		s.passBarrier(wf.WG)
 		s.resetRegisterValue(wf)
 
 		wf.State = wavefront.WfCompleted
 
 		tracing.EndTask(s.cu.comp, tracing.TaskEnd{ID: wf.UID})
-
-		return true, true
-	}
-
-	if s.atLeaseOneWfIsExecuting(wf.WG) {
+	} else if s.atLeaseOneWfIsExecuting(wf.WG) {
 		s.resetRegisterValue(wf)
 
 		wf.State = wavefront.WfCompleted
 
 		s.cu.logInstTask(wf, wf.DynamicInst(), true)
 		tracing.EndTask(s.cu.comp, tracing.TaskEnd{ID: wf.UID})
-
-		return true, true
+	} else {
+		panic("never")
 	}
 
-	panic("never")
+	// S_ENDPGM has retired: mark the end of the drain wait exactly once, here,
+	// where the path can no longer return false and retry. An ACE-port-full
+	// retry returns above before reaching this point, so it does not re-emit.
+	s.markMemDrained(wf, "s_endpgm")
+
+	return true, true
 }
 
 func (s *SchedulerImpl) areAllOtherWfsInWGCompleted(

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -331,11 +331,22 @@ func (s *SchedulerImpl) evalSEndPgm(
 		}
 	}
 
-	if s.areAllOtherWfsInWGCompleted(wf.WG, wf) {
-		done := s.sendWGCompletionMessage(wf.WG)
-		if !done {
-			return false, false
-		}
+	allCompleted := s.areAllOtherWfsInWGCompleted(wf.WG, wf)
+
+	// The only path that cannot retire this tick is the work-group-completing
+	// one when the ACE port is full. Decide that here, before emitting the
+	// milestone, so a retry does not re-emit it.
+	if allCompleted && !s.cu.acePort().CanSend() {
+		return false, false
+	}
+
+	// S_ENDPGM will retire this tick: mark the end of the drain wait exactly
+	// once, before any branch below ends the inst task (the barrier and
+	// executing paths close it via logInstTask).
+	s.markMemDrained(wf, "s_endpgm")
+
+	if allCompleted {
+		s.sendWGCompletionMessage(wf.WG)
 
 		wf.State = wavefront.WfCompleted
 
@@ -361,11 +372,6 @@ func (s *SchedulerImpl) evalSEndPgm(
 	} else {
 		panic("never")
 	}
-
-	// S_ENDPGM has retired: mark the end of the drain wait exactly once, here,
-	// where the path can no longer return false and retry. An ACE-port-full
-	// retry returns above before reaching this point, so it does not re-emit.
-	s.markMemDrained(wf, "s_endpgm")
 
 	return true, true
 }

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -321,11 +321,7 @@ func (s *SchedulerImpl) evalSEndPgm(
 
 	// The wavefront's outstanding memory accesses have all returned, so
 	// S_ENDPGM can retire: mark the end of that drain wait.
-	tracing.AddMilestone(s.cu.comp, tracing.Milestone{
-		TaskID: wf.DynamicInst().ID,
-		Kind:   tracing.MilestoneKindData,
-		What:   "s_endpgm",
-	})
+	s.markMemDrained(wf, "s_endpgm")
 
 	// sampling
 	now := s.cu.CurrentTime()
@@ -562,16 +558,22 @@ func (s *SchedulerImpl) evalSWaitCnt(
 	if done {
 		// The outstanding memory accesses the S_WAITCNT was waiting on have
 		// drained to the requested counts: mark the end of that wait.
-		tracing.AddMilestone(s.cu.comp, tracing.Milestone{
-			TaskID: wf.DynamicInst().ID,
-			Kind:   tracing.MilestoneKindData,
-			What:   "s_waitcnt",
-		})
+		s.markMemDrained(wf, "s_waitcnt")
 		s.cu.UpdatePCAndSetReady(wf)
 		return true, true
 	}
 
 	return false, false
+}
+
+// markMemDrained records a "data" milestone on a wavefront's instruction task,
+// marking the moment the memory accesses it was waiting on have drained.
+func (s *SchedulerImpl) markMemDrained(wf *wavefront.Wavefront, what string) {
+	tracing.AddMilestone(s.cu.comp, tracing.Milestone{
+		TaskID: wf.DynamicInst().ID,
+		Kind:   tracing.MilestoneKindData,
+		What:   what,
+	})
 }
 
 // Pause pauses

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -319,6 +319,14 @@ func (s *SchedulerImpl) evalSEndPgm(
 		return false, false
 	}
 
+	// The wavefront's outstanding memory accesses have all returned, so
+	// S_ENDPGM can retire: mark the end of that drain wait.
+	tracing.AddMilestone(s.cu.comp, tracing.Milestone{
+		TaskID: wf.DynamicInst().ID,
+		Kind:   tracing.MilestoneKindData,
+		What:   "s_endpgm",
+	})
+
 	// sampling
 	now := s.cu.CurrentTime()
 	if *sampling.SampledRunnerFlag {
@@ -552,6 +560,13 @@ func (s *SchedulerImpl) evalSWaitCnt(
 	}
 
 	if done {
+		// The outstanding memory accesses the S_WAITCNT was waiting on have
+		// drained to the requested counts: mark the end of that wait.
+		tracing.AddMilestone(s.cu.comp, tracing.Milestone{
+			TaskID: wf.DynamicInst().ID,
+			Kind:   tracing.MilestoneKindData,
+			What:   "s_waitcnt",
+		})
 		s.cu.UpdatePCAndSetReady(wf)
 		return true, true
 	}

--- a/amd/timing/cu/simdunit.go
+++ b/amd/timing/cu/simdunit.go
@@ -173,6 +173,14 @@ func (u *SIMDUnit) Flush() {
 // logPipelineTaskStart starts the per-SIMD pipeline task for the given
 // instruction and returns the task ID (v4 used the string ID
 // inst.ID+"_simd_exec").
+//
+// The task is emitted on the SIMD unit itself (domain u), not on cu.comp, on
+// purpose: report.go attaches a per-SIMD BusyTimeTracer to each SIMD unit
+// filtered to Kind=="pipeline" to measure per-SIMD busy time, which requires
+// the task to live on that unit's own tracing domain. Its parent ("inst")
+// lives on cu.comp; that cross-domain parent link still resolves because the
+// vis DBTracer is the same instance on both domains. Do not move this to
+// cu.comp — it would collapse the per-SIMD busy-time metric.
 func (u *SIMDUnit) logPipelineTaskStart(inst *wavefront.Inst) uint64 {
 	taskID := timing.GetIDGenerator().Generate()
 

--- a/amd/timing/cu/simdunit.go
+++ b/amd/timing/cu/simdunit.go
@@ -156,6 +156,16 @@ func (u *SIMDUnit) runExecStage() bool {
 
 // Flush flushes
 func (u *SIMDUnit) Flush() {
+	// End the per-SIMD "pipeline" tasks of the instructions dropped from the
+	// pipeline, so they do not leak as started-never-ended. (The instructions'
+	// parent "inst" tasks are ended by ComputeUnit.endInflightTracingTasks.)
+	if u.toExec != nil {
+		tracing.EndTaskOnReset(u, u.execTaskID)
+	}
+	for _, slot := range u.pipelineSlots {
+		tracing.EndTaskOnReset(u, slot.taskID)
+	}
+
 	u.toExec = nil
 	u.pipelineSlots = u.pipelineSlots[:0]
 }

--- a/amd/timing/cu/vectormemoryunit.go
+++ b/amd/timing/cu/vectormemoryunit.go
@@ -72,9 +72,11 @@ func (u *VectorMemoryUnit) startIssueSubtask(inst *wavefront.Inst) {
 }
 
 // endIssueSubtask closes an instruction's issue subtask (if still open) when
-// its first transaction is sent, and emits the "work" milestone the subtask
-// backs. Later transactions of the same instruction find no open subtask and
-// are no-ops, so the milestone lands at the first send.
+// its first transaction reaches the head of the send buffer (the issue work is
+// done), and emits the "work" milestone the subtask backs. Later transactions
+// of the same instruction — and port-full retries on the same one — find no
+// open subtask and are no-ops, so the milestone lands once, at the moment the
+// transaction is ready to send rather than when it actually leaves.
 func (u *VectorMemoryUnit) endIssueSubtask(inst *wavefront.Inst) {
 	taskID, ok := u.issueTaskIDs[inst.ID]
 	if !ok {
@@ -339,6 +341,15 @@ func (u *VectorMemoryUnit) sendRequest() bool {
 
 		info := u.postTransactionPipelineBuffer.Peek()
 
+		// The transaction has reached the head of the send buffer: the
+		// coalescing / transaction-issue work is done. Close the issue subtask
+		// and emit the "coalesce" work milestone now — before the CanSend check
+		// below — so that port backpressure (cycles spent waiting to send) is
+		// not counted as coalescing work. It is idempotent (only the first
+		// transaction per instruction finds an open subtask), so a port-full
+		// retry on the same transaction does not re-emit it.
+		u.endIssueSubtask(info.Inst)
+
 		var req messaging.Msg
 		if info.Read != nil {
 			req = *info.Read
@@ -354,13 +365,6 @@ func (u *VectorMemoryUnit) sendRequest() bool {
 		u.postTransactionPipelineBuffer.Pop()
 		u.numTransactionInFlight--
 
-		// The first transaction for this instruction is leaving the unit: close
-		// the issue subtask and mark the end of the coalescing /
-		// transaction-issue work. This separates the issue phase (work) from the
-		// data wait, which only begins once a request is actually outstanding —
-		// the subtask bar and the work milestone span exactly the interval
-		// before the req_out subtasks start.
-		u.endIssueSubtask(info.Inst)
 		tracing.TraceReqInitiate(u.cu.comp, req, info.Inst.ID)
 		madeProgress = true
 	}

--- a/amd/timing/cu/vectormemoryunit.go
+++ b/amd/timing/cu/vectormemoryunit.go
@@ -373,9 +373,18 @@ func (u *VectorMemoryUnit) sendRequest() bool {
 
 // Flush flushes
 func (u *VectorMemoryUnit) Flush() {
-	// End any open issue subtasks so they do not leak as started-never-ended
-	// (their parent inst tasks are ended by ComputeUnit.endInflightTracingTasks).
-	for _, id := range u.issueTaskIDs {
+	// An instruction flushed between admission and its first send keeps its
+	// parent inst task — it is WfReady, so endInflightTracingTasks leaves it
+	// open for the shadow response — but the shadow resend bypasses this unit
+	// and never calls endIssueSubtask. Emit the coalesce work milestone and end
+	// its subtask here, so the issue work is still attributed (and the subtask
+	// does not leak) rather than folding into the post-flush data wait.
+	for instID, id := range u.issueTaskIDs {
+		tracing.AddMilestone(u.cu.comp, tracing.Milestone{
+			TaskID: instID,
+			Kind:   tracing.MilestoneKindWork,
+			What:   "coalesce",
+		})
 		tracing.EndTaskOnReset(u.cu.comp, id)
 	}
 	u.issueTaskIDs = make(map[uint64]uint64)

--- a/amd/timing/cu/vectormemoryunit.go
+++ b/amd/timing/cu/vectormemoryunit.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sarchlab/akita/v5/messaging"
 	"github.com/sarchlab/akita/v5/queueing"
+	"github.com/sarchlab/akita/v5/timing"
 	"github.com/sarchlab/akita/v5/tracing"
 	"github.com/sarchlab/mgpusim/v5/amd/insts"
 	"github.com/sarchlab/mgpusim/v5/amd/timing/wavefront"
@@ -34,6 +35,11 @@ type VectorMemoryUnit struct {
 	transactionPipeline           queueing.Pipeline[VectorMemAccessInfo]
 	postTransactionPipelineBuffer queueing.Buffer[VectorMemAccessInfo]
 
+	// issueTaskIDs maps an instruction's task ID to the "pipeline" subtask
+	// that records its coalescing / transaction-issue work — opened when its
+	// transactions are admitted and closed when the first one is sent.
+	issueTaskIDs map[uint64]uint64
+
 	isIdle bool
 }
 
@@ -45,8 +51,43 @@ func NewVectorMemoryUnit(
 	u := new(VectorMemoryUnit)
 	u.cu = cu
 	u.coalescer = coalescer
+	u.issueTaskIDs = make(map[uint64]uint64)
 
 	return u
+}
+
+// startIssueSubtask opens the "pipeline" subtask that spans an instruction's
+// coalescing / transaction-issue work (from the in-flight admission to the
+// first transaction send), parented to the instruction's task. It is the child
+// subtask that backs the "work" milestone emitted at first send.
+func (u *VectorMemoryUnit) startIssueSubtask(inst *wavefront.Inst) {
+	taskID := timing.GetIDGenerator().Generate()
+	tracing.StartTask(u.cu.comp, tracing.TaskStart{
+		ID:       taskID,
+		ParentID: inst.ID,
+		Kind:     "pipeline",
+		What:     "coalesce",
+	})
+	u.issueTaskIDs[inst.ID] = taskID
+}
+
+// endIssueSubtask closes an instruction's issue subtask (if still open) when
+// its first transaction is sent, and emits the "work" milestone the subtask
+// backs. Later transactions of the same instruction find no open subtask and
+// are no-ops, so the milestone lands at the first send.
+func (u *VectorMemoryUnit) endIssueSubtask(inst *wavefront.Inst) {
+	taskID, ok := u.issueTaskIDs[inst.ID]
+	if !ok {
+		return
+	}
+
+	tracing.EndTask(u.cu.comp, tracing.TaskEnd{ID: taskID})
+	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
+		TaskID: inst.ID,
+		Kind:   tracing.MilestoneKindWork,
+		What:   "coalesce",
+	})
+	delete(u.issueTaskIDs, inst.ID)
 }
 
 // CanAcceptWave checks if the buffer of the read stage is occupied or not
@@ -210,12 +251,15 @@ func (u *VectorMemoryUnit) executeFlatLoad(
 	}
 
 	// The in-flight vector-memory-access budget admitted this instruction's
-	// transactions: mark the resolution of any wait for a free slot.
+	// transactions: mark the resolution of any wait for a free slot, then open
+	// the subtask that records the coalescing / transaction-issue work until
+	// the first transaction is sent.
 	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
 		TaskID: wave.DynamicInst().ID,
 		Kind:   tracing.MilestoneKindHardwareResource,
 		What:   "vmem-inflight",
 	})
+	u.startIssueSubtask(wave.DynamicInst())
 
 	wave.OutstandingVectorMemAccess++
 	wave.OutstandingScalarMemAccess++
@@ -257,12 +301,15 @@ func (u *VectorMemoryUnit) executeFlatStore(
 	}
 
 	// The in-flight vector-memory-access budget admitted this instruction's
-	// transactions: mark the resolution of any wait for a free slot.
+	// transactions: mark the resolution of any wait for a free slot, then open
+	// the subtask that records the coalescing / transaction-issue work until
+	// the first transaction is sent.
 	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
 		TaskID: wave.DynamicInst().ID,
 		Kind:   tracing.MilestoneKindHardwareResource,
 		What:   "vmem-inflight",
 	})
+	u.startIssueSubtask(wave.DynamicInst())
 
 	wave.OutstandingVectorMemAccess++
 	wave.OutstandingScalarMemAccess++
@@ -307,18 +354,13 @@ func (u *VectorMemoryUnit) sendRequest() bool {
 		u.postTransactionPipelineBuffer.Pop()
 		u.numTransactionInFlight--
 
-		// The first transaction for this instruction is leaving the unit: mark
-		// the end of the coalescing / transaction-issue phase. The DBTracer
-		// keeps the first such milestone per task, so it lands at the first
-		// send — separating the issue phase from the data wait, which only
-		// begins once a request is actually outstanding. Without it the time
-		// between the in-flight admission and the first send is mis-attributed
-		// to the data wait (the subtask bars start only here).
-		tracing.AddMilestone(u.cu.comp, tracing.Milestone{
-			TaskID: info.Inst.ID,
-			Kind:   tracing.MilestoneKindHardwareResource,
-			What:   "coalesce",
-		})
+		// The first transaction for this instruction is leaving the unit: close
+		// the issue subtask and mark the end of the coalescing /
+		// transaction-issue work. This separates the issue phase (work) from the
+		// data wait, which only begins once a request is actually outstanding —
+		// the subtask bar and the work milestone span exactly the interval
+		// before the req_out subtasks start.
+		u.endIssueSubtask(info.Inst)
 		tracing.TraceReqInitiate(u.cu.comp, req, info.Inst.ID)
 		madeProgress = true
 	}
@@ -327,6 +369,13 @@ func (u *VectorMemoryUnit) sendRequest() bool {
 
 // Flush flushes
 func (u *VectorMemoryUnit) Flush() {
+	// End any open issue subtasks so they do not leak as started-never-ended
+	// (their parent inst tasks are ended by ComputeUnit.endInflightTracingTasks).
+	for _, id := range u.issueTaskIDs {
+		tracing.EndTaskOnReset(u.cu.comp, id)
+	}
+	u.issueTaskIDs = make(map[uint64]uint64)
+
 	u.instructionPipeline.Clear()
 	u.transactionPipeline.Clear()
 	u.postInstructionPipelineBuffer.Clear()

--- a/amd/timing/cu/vectormemoryunit.go
+++ b/amd/timing/cu/vectormemoryunit.go
@@ -209,6 +209,14 @@ func (u *VectorMemoryUnit) executeFlatLoad(
 		return false
 	}
 
+	// The in-flight vector-memory-access budget admitted this instruction's
+	// transactions: mark the resolution of any wait for a free slot.
+	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
+		TaskID: wave.DynamicInst().ID,
+		Kind:   tracing.MilestoneKindHardwareResource,
+		What:   "vmem-inflight",
+	})
+
 	wave.OutstandingVectorMemAccess++
 	wave.OutstandingScalarMemAccess++
 
@@ -247,6 +255,14 @@ func (u *VectorMemoryUnit) executeFlatStore(
 		u.cu.InFlightVectorMemAccessLimit {
 		return false
 	}
+
+	// The in-flight vector-memory-access budget admitted this instruction's
+	// transactions: mark the resolution of any wait for a free slot.
+	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
+		TaskID: wave.DynamicInst().ID,
+		Kind:   tracing.MilestoneKindHardwareResource,
+		What:   "vmem-inflight",
+	})
 
 	wave.OutstandingVectorMemAccess++
 	wave.OutstandingScalarMemAccess++

--- a/amd/timing/cu/vectormemoryunit.go
+++ b/amd/timing/cu/vectormemoryunit.go
@@ -306,6 +306,19 @@ func (u *VectorMemoryUnit) sendRequest() bool {
 		u.cu.vectorMemPort().Send(req)
 		u.postTransactionPipelineBuffer.Pop()
 		u.numTransactionInFlight--
+
+		// The first transaction for this instruction is leaving the unit: mark
+		// the end of the coalescing / transaction-issue phase. The DBTracer
+		// keeps the first such milestone per task, so it lands at the first
+		// send — separating the issue phase from the data wait, which only
+		// begins once a request is actually outstanding. Without it the time
+		// between the in-flight admission and the first send is mis-attributed
+		// to the data wait (the subtask bars start only here).
+		tracing.AddMilestone(u.cu.comp, tracing.Milestone{
+			TaskID: info.Inst.ID,
+			Kind:   tracing.MilestoneKindHardwareResource,
+			What:   "coalesce",
+		})
 		tracing.TraceReqInitiate(u.cu.comp, req, info.Inst.ID)
 		madeProgress = true
 	}

--- a/amd/timing/rdma/comp.go
+++ b/amd/timing/rdma/comp.go
@@ -35,6 +35,11 @@ type transaction struct {
 	// RecvTaskID is the tracing task ID at the receiver side for the
 	// original request. Zero when tracing is disabled.
 	RecvTaskID uint64 `json:"recv_task_id"`
+
+	// RemoteMilestoneEmitted records whether the "remote" data milestone has
+	// been emitted (when the response first arrived), so that egress-port
+	// backpressure retries do not emit it again.
+	RemoteMilestoneEmitted bool `json:"remote_milestone_emitted"`
 }
 
 // State contains the mutable runtime data of the RDMA engine.

--- a/amd/timing/rdma/middleware.go
+++ b/amd/timing/rdma/middleware.go
@@ -207,6 +207,14 @@ func (m *forwardMiddleware) endTransaction(trans transaction) {
 		return
 	}
 
+	// The forwarded request's response has arrived: mark the end of the time
+	// the req_in spent waiting on the round trip to the other side.
+	tracing.AddMilestone(m.comp, tracing.Milestone{
+		TaskID: trans.RecvTaskID,
+		Kind:   tracing.MilestoneKindData,
+		What:   "remote",
+	})
+
 	tracing.EndTask(m.comp, tracing.TaskEnd{ID: trans.ForwardedReqID})
 	tracing.EndTask(m.comp, tracing.TaskEnd{ID: trans.RecvTaskID})
 	tracing.ForgetMsgIDAtReceiver(trans.OriginalReqID, m.comp)

--- a/amd/timing/rdma/middleware.go
+++ b/amd/timing/rdma/middleware.go
@@ -99,6 +99,15 @@ func (m *forwardMiddleware) processIncomingRsp() bool {
 		rsp.Meta().RspTo, state.TransactionsFromInside)
 	trans := state.TransactionsFromInside[index]
 
+	// The remote response has arrived: end the remote round-trip wait now,
+	// before the egress-port backpressure below, so the wait to forward the
+	// response is not charged to the remote interval. Guard so an egress-full
+	// retry does not re-emit.
+	if !trans.RemoteMilestoneEmitted {
+		m.markRemoteRoundTripDone(trans)
+		state.TransactionsFromInside[index].RemoteMilestoneEmitted = true
+	}
+
 	inPort := m.port("RDMARequestInside")
 	if !inPort.CanSend() {
 		return false
@@ -167,6 +176,15 @@ func (m *forwardMiddleware) processFromL2() bool {
 		rsp.Meta().RspTo, state.TransactionsFromOutside)
 	trans := state.TransactionsFromOutside[index]
 
+	// The remote response has arrived: end the remote round-trip wait now,
+	// before the egress-port backpressure below, so the wait to forward the
+	// response is not charged to the remote interval. Guard so an egress-full
+	// retry does not re-emit.
+	if !trans.RemoteMilestoneEmitted {
+		m.markRemoteRoundTripDone(trans)
+		state.TransactionsFromOutside[index].RemoteMilestoneEmitted = true
+	}
+
 	outPort := m.port("RDMADataOutside")
 	if !outPort.CanSend() {
 		return false
@@ -201,19 +219,27 @@ func (m *forwardMiddleware) startTransaction(
 	}
 }
 
-// endTransaction ends the tracing tasks for a completed transaction.
-func (m *forwardMiddleware) endTransaction(trans transaction) {
+// markRemoteRoundTripDone emits the "remote" data milestone for a transaction
+// when its response first arrives — before any egress-port backpressure — so
+// the wait to forward the response is not charged to the remote round-trip
+// interval. Callers guard against re-emission via Transaction.RemoteMilestoneEmitted.
+func (m *forwardMiddleware) markRemoteRoundTripDone(trans transaction) {
 	if m.comp.NumHooks() == 0 {
 		return
 	}
 
-	// The forwarded request's response has arrived: mark the end of the time
-	// the req_in spent waiting on the round trip to the other side.
 	tracing.AddMilestone(m.comp, tracing.Milestone{
 		TaskID: trans.RecvTaskID,
 		Kind:   tracing.MilestoneKindData,
 		What:   "remote",
 	})
+}
+
+// endTransaction ends the tracing tasks for a completed transaction.
+func (m *forwardMiddleware) endTransaction(trans transaction) {
+	if m.comp.NumHooks() == 0 {
+		return
+	}
 
 	tracing.EndTask(m.comp, tracing.TaskEnd{ID: trans.ForwardedReqID})
 	tracing.EndTask(m.comp, tracing.TaskEnd{ID: trans.RecvTaskID})

--- a/amd/timing/rdma/milestone_tracing_test.go
+++ b/amd/timing/rdma/milestone_tracing_test.go
@@ -1,0 +1,101 @@
+package rdma
+
+import (
+	"testing"
+
+	"github.com/sarchlab/akita/v5/mem"
+	"github.com/sarchlab/akita/v5/mem/memprotocol"
+	"github.com/sarchlab/akita/v5/messaging"
+	"github.com/sarchlab/akita/v5/modeling"
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
+)
+
+type milestoneRecorder struct {
+	tracing.NopTracer
+
+	milestones []tracing.Milestone
+}
+
+func (r *milestoneRecorder) AddMilestone(m tracing.Milestone) {
+	r.milestones = append(r.milestones, m)
+}
+
+// When a forwarded request's response returns, the RDMA engine must record a
+// "data" milestone on the req_in task, attributing the time spent waiting on
+// the round trip to the other side.
+func TestRDMARecordsDataMilestoneOnResponse(t *testing.T) {
+	engine := timing.NewSerialEngine()
+	localCache := messaging.RemotePort("LocalCache")
+	remoteGPU := messaging.RemotePort("RemoteGPU")
+
+	rdmaEngine := MakeBuilder().
+		WithRegistrar(modeling.NewStandaloneRegistrar(engine)).
+		WithResources(Resources{
+			LocalModules:           &mem.SinglePortMapper{Port: localCache},
+			RemoteRDMAAddressTable: &mem.SinglePortMapper{Port: remoteGPU},
+		}).
+		Build("RDMAEngine")
+
+	makePort := func(name string) messaging.Port {
+		port := messaging.NewPort(
+			rdmaEngine, 4, 4, rdmaEngine.Name()+"."+name)
+		rdmaEngine.AssignPort(name, port)
+		(&noopConn{}).PlugIn(port)
+		return port
+	}
+	makePort("RDMARequestInside")
+	requestOutside := makePort("RDMARequestOutside")
+	makePort("RDMADataInside")
+	makePort("RDMADataOutside")
+	makePort("Ctrl")
+
+	rec := &milestoneRecorder{}
+	tracing.CollectTrace(rdmaEngine, rec)
+
+	var mw *forwardMiddleware
+	for _, m := range rdmaEngine.Middlewares() {
+		if fm, ok := m.(*forwardMiddleware); ok {
+			mw = fm
+		}
+	}
+	if mw == nil {
+		t.Fatal("forwardMiddleware not found")
+	}
+
+	forwardedID := timing.GetIDGenerator().Generate()
+	recvTaskID := timing.GetIDGenerator().Generate()
+	rdmaEngine.State.TransactionsFromInside = append(
+		rdmaEngine.State.TransactionsFromInside,
+		transaction{
+			OriginalReqID:  timing.GetIDGenerator().Generate(),
+			OriginalSrc:    localCache,
+			ForwardedReqID: forwardedID,
+			RecvTaskID:     recvTaskID,
+		})
+
+	requestOutside.Deliver(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			Src:   remoteGPU,
+			Dst:   requestOutside.AsRemote(),
+			RspTo: forwardedID,
+		},
+		Data: []byte{1, 2, 3, 4},
+	})
+
+	mw.Tick()
+
+	found := false
+	for _, ms := range rec.milestones {
+		if ms.TaskID == recvTaskID &&
+			ms.Kind == tracing.MilestoneKindData &&
+			ms.What == "remote" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a data milestone on the req_in, got %+v",
+			rec.milestones)
+	}
+}

--- a/amd/timing/rdma/milestone_tracing_test.go
+++ b/amd/timing/rdma/milestone_tracing_test.go
@@ -21,34 +21,37 @@ func (r *milestoneRecorder) AddMilestone(m tracing.Milestone) {
 	r.milestones = append(r.milestones, m)
 }
 
-// When a forwarded request's response returns, the RDMA engine must record a
-// "data" milestone on the req_in task, attributing the time spent waiting on
-// the round trip to the other side.
-func TestRDMARecordsDataMilestoneOnResponse(t *testing.T) {
-	engine := timing.NewSerialEngine()
-	localCache := messaging.RemotePort("LocalCache")
-	remoteGPU := messaging.RemotePort("RemoteGPU")
+const localCache = messaging.RemotePort("LocalCache")
+const remoteGPU = messaging.RemotePort("RemoteGPU")
+
+// buildTracedRDMA builds an RDMA engine with all five ports plugged into a
+// noop connection and a milestone recorder attached, returning the engine, its
+// forward middleware, the outside request port, and the recorder.
+func buildTracedRDMA(t *testing.T) (
+	*Comp, *forwardMiddleware, messaging.Port, *milestoneRecorder,
+) {
+	t.Helper()
 
 	rdmaEngine := MakeBuilder().
-		WithRegistrar(modeling.NewStandaloneRegistrar(engine)).
+		WithRegistrar(modeling.NewStandaloneRegistrar(timing.NewSerialEngine())).
 		WithResources(Resources{
 			LocalModules:           &mem.SinglePortMapper{Port: localCache},
 			RemoteRDMAAddressTable: &mem.SinglePortMapper{Port: remoteGPU},
 		}).
 		Build("RDMAEngine")
 
-	makePort := func(name string) messaging.Port {
-		port := messaging.NewPort(
-			rdmaEngine, 4, 4, rdmaEngine.Name()+"."+name)
+	var requestOutside messaging.Port
+	for _, name := range []string{
+		"RDMARequestInside", "RDMARequestOutside",
+		"RDMADataInside", "RDMADataOutside", "Ctrl",
+	} {
+		port := messaging.NewPort(rdmaEngine, 4, 4, rdmaEngine.Name()+"."+name)
 		rdmaEngine.AssignPort(name, port)
 		(&noopConn{}).PlugIn(port)
-		return port
+		if name == "RDMARequestOutside" {
+			requestOutside = port
+		}
 	}
-	makePort("RDMARequestInside")
-	requestOutside := makePort("RDMARequestOutside")
-	makePort("RDMADataInside")
-	makePort("RDMADataOutside")
-	makePort("Ctrl")
 
 	rec := &milestoneRecorder{}
 	tracing.CollectTrace(rdmaEngine, rec)
@@ -62,6 +65,15 @@ func TestRDMARecordsDataMilestoneOnResponse(t *testing.T) {
 	if mw == nil {
 		t.Fatal("forwardMiddleware not found")
 	}
+
+	return rdmaEngine, mw, requestOutside, rec
+}
+
+// When a forwarded request's response returns, the RDMA engine must record a
+// "data" milestone on the req_in task, attributing the time spent waiting on
+// the round trip to the other side.
+func TestRDMARecordsDataMilestoneOnResponse(t *testing.T) {
+	rdmaEngine, mw, requestOutside, rec := buildTracedRDMA(t)
 
 	forwardedID := timing.GetIDGenerator().Generate()
 	recvTaskID := timing.GetIDGenerator().Generate()

--- a/amd/timing/rdma/milestone_tracing_test.go
+++ b/amd/timing/rdma/milestone_tracing_test.go
@@ -111,3 +111,60 @@ func TestRDMARecordsDataMilestoneOnResponse(t *testing.T) {
 			rec.milestones)
 	}
 }
+
+// Egress-port backpressure must not delay or duplicate the remote milestone:
+// it is emitted when the response arrives, even if the response cannot be
+// forwarded yet, and exactly once across retries.
+func TestRDMARemoteMilestoneNotDelayedByEgressBackpressure(t *testing.T) {
+	rdmaEngine, mw, requestOutside, rec := buildTracedRDMA(t)
+
+	// Saturate the egress port so the arrived response cannot be forwarded.
+	inPort := rdmaEngine.GetPortByName("RDMARequestInside")
+	for i := 0; i < 100 && inPort.CanSend(); i++ {
+		inPort.Send(memprotocol.WriteDoneRsp{
+			MsgMeta: messaging.MsgMeta{
+				ID:  timing.GetIDGenerator().Generate(),
+				Src: inPort.AsRemote(),
+				Dst: remoteGPU,
+			},
+		})
+	}
+	if inPort.CanSend() {
+		t.Skip("could not saturate the egress port")
+	}
+
+	forwardedID := timing.GetIDGenerator().Generate()
+	recvTaskID := timing.GetIDGenerator().Generate()
+	rdmaEngine.State.TransactionsFromInside = append(
+		rdmaEngine.State.TransactionsFromInside,
+		transaction{
+			OriginalReqID:  timing.GetIDGenerator().Generate(),
+			OriginalSrc:    localCache,
+			ForwardedReqID: forwardedID,
+			RecvTaskID:     recvTaskID,
+		})
+
+	requestOutside.Deliver(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			RspTo: forwardedID,
+		},
+	})
+
+	// Tick twice while the egress port stays full: the response stays
+	// unforwarded, but the remote milestone fires once, at arrival.
+	mw.Tick()
+	mw.Tick()
+
+	count := 0
+	for _, ms := range rec.milestones {
+		if ms.TaskID == recvTaskID &&
+			ms.Kind == tracing.MilestoneKindData && ms.What == "remote" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("remote milestone should be emitted once at arrival even "+
+			"under egress backpressure; got %d", count)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/onsi/ginkgo/v2 v2.25.1
 	github.com/onsi/gomega v1.38.1
-	github.com/sarchlab/akita/v5 v5.0.0-beta.6
+	github.com/sarchlab/akita/v5 v5.0.0-beta.7
 	github.com/tebeka/atexit v0.3.0
 	go.uber.org/mock v0.6.0
 	gonum.org/v1/gonum v0.15.1
@@ -34,6 +34,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/syifan/goseth v0.1.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/onsi/ginkgo/v2 v2.25.1 h1:Fwp6crTREKM+oA6Cz4MsO8RhKQzs2/gOIVOUscMAfZY=
 github.com/onsi/ginkgo/v2 v2.25.1/go.mod h1:ppTWQ1dh9KM/F1XgpeRqelR+zHVwV81DGRSDnFxK7Sk=
 github.com/onsi/gomega v1.38.1 h1:FaLA8GlcpXDwsb7m0h2A9ew2aTk3vnZMlzFgg5tz/pk=
@@ -50,8 +52,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
-github.com/sarchlab/akita/v5 v5.0.0-beta.6 h1:pkYMmaA0z0H27V3rHEI5Jlu1H2ZODyvl9iMVTgy9yqE=
-github.com/sarchlab/akita/v5 v5.0.0-beta.6/go.mod h1:dtmkH7OerTe5QB/3GbQ4YN96jppHuaDcofClhPP2qlo=
+github.com/sarchlab/akita/v5 v5.0.0-beta.7 h1:ciT8jXGYXG4bXFGiu6ReQLQkM0ZuGhL1Kw3WgdCciHI=
+github.com/sarchlab/akita/v5 v5.0.0-beta.7/go.mod h1:/2uOHfnAJFZCMufMx7a5tXUsdAdgP2XiL9ssc2C4Za8=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Brings MGPUSim's own timing components up to the akita v5 task-tracing
convention. The reused `mem/` hierarchy was already well-instrumented inside
akita, but MGPUSim's compute/control components (CU, CP, DMA, dispatcher, RDMA)
had **zero milestones/tags** and several **tracing-task leaks**. This PR fixes
the leaks and adds blocked-time attribution where a task spans the wait.

## Step 0 — bump akita to v5.0.0-beta.7
Zero source changes required. beta.7 adds the reset helpers
(`EndReqInOnReset`/`EndTaskOnReset`), the buffer-admission registry
(`MsgIDAtIncomingBuffer`), `MilestoneKindWork`, auto-attached incoming+outgoing
buffer port tracing, and `tracingtest.LeakRecorder`.

## Step 1 — stop tracing-task leaks (correctness)
- **CU pipeline flush** dropped the tasks of the work it discarded. Now
  `endInflightTracingTasks` ends the inst task of every running wavefront
  (covering all sub-units + the scheduler's `internalExecuting`), `SIMDUnit.Flush`
  ends the per-SIMD `pipeline` tasks, `populateShadowBuffers` ends the
  shadow-resend `req_out` originals, and the sampled-run path ends **all**
  wavefront tasks in a work-group (not just the one whose completion event fired).
- **CP `FlushReq` `req_in`** was opened but never completed — now completed on the
  flush-done response.

## Step 2 — blocked-time milestones
Admission waits hang on the incoming-buffer task; processing waits on the
req_in / inst task.

| Component | Milestone | Kind |
|---|---|---|
| DMA | `processing slot` / `ToMem` | hardware_resource / data |
| CP | `dispatcher` / `ToDMA` | hardware_resource / network_busy |
| RDMA | `remote` (round trip) | data |
| CU | `vmem-inflight` → `coalesce` → `vmem`/`smem` | hardware_resource → work → data |
| CU | `s_waitcnt` / `s_endpgm` | data |

A vector-memory instruction now tiles cleanly into **vmem-inflight**
(in-flight slot, `hardware_resource`) → **coalesce** (the coalescing /
transaction-issue work, `work`, backed by a `pipeline` child subtask) →
**data** (the memory round trip, aligned with the `req_out` transaction bars).

## Step 5 — documentation, not change
Two flagged "cross-domain parentage" issues are correct by design given the
shared vis DBTracer (SIMD `pipeline` tasks must stay on the SIMD-unit domain for
the per-SIMD busy tracer; the dispatcher's `MapWGReq` parent resolves in the one
trace DB). Documented at each site so a future audit doesn't "fix" and regress.

Not in scope (per request): tags, and full control-plane instrumentation beyond
the FlushReq leak. CU pre-issue stalls (`CanAcceptWave`, `!CanSend`) are left
uninstrumented — those waits precede the instruction's task.

`amd/timing/TRACING.md` documents the lifecycle, milestone table, and the
intentional gaps.

## Verification
- `go build ./...`, `go vet ./...` clean; golangci-lint 0 issues on touched packages.
- All `amd/timing/...` + `amd/driver/...` tests pass, including new
  `LeakRecorder` leak tests and milestone-recording tests per component.
- **End-to-end**: a traced FIR run produces every new milestone, all 136 VMem
  inst tasks carry the full vmem-inflight→coalesce→data tiling with 0 trailing
  gaps and 136 `pipeline` subtasks paired 1:1 with the work milestones (0 leaked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)