### PR TITLE
ci: run regular tests on GitHub-hosted runners (parallel acceptance on Github-Large-1)

### DIFF
--- a/.github/workflows/mgpusim_test.yml
+++ b/.github/workflows/mgpusim_test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   compile:
     name: Compile
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -62,7 +62,7 @@ jobs:
 
   unit_test:
     name: Unit Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [compile, lint]
     steps:
       - name: Checkout
@@ -94,7 +94,7 @@ jobs:
 
   deterministicity_test:
     name: Deterministicity Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [unit_test]
     steps:
       - name: Checkout
@@ -124,7 +124,7 @@ jobs:
 
   disassembler_test:
     name: Disassembler Test (GFX942)
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [compile]
     steps:
       - name: Checkout
@@ -152,7 +152,7 @@ jobs:
 
   gcn3_emu_test:
     name: GCN3 Emulation Test
-    runs-on: self-hosted
+    runs-on: Github-Large-1
     needs: [unit_test]
     steps:
       - name: Checkout
@@ -179,7 +179,7 @@ jobs:
 
   gcn3_single_gpu_timing_test:
     name: GCN3 Single GPU Timing Test (${{ matrix.shard.name }})
-    runs-on: self-hosted
+    runs-on: Github-Large-1
     needs: [gcn3_emu_test]
     strategy:
       fail-fast: false
@@ -224,7 +224,7 @@ jobs:
 
   cdna3_emu_test:
     name: CDNA3 Emulation Test
-    runs-on: self-hosted
+    runs-on: Github-Large-1
     needs: [unit_test]
     steps:
       - name: Checkout
@@ -251,7 +251,7 @@ jobs:
 
   cdna3_single_gpu_timing_test:
     name: CDNA3 Single GPU Timing Test
-    runs-on: self-hosted
+    runs-on: Github-Large-1
     needs: [cdna3_emu_test]
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why

Our self-hosted runners are saturated by MI300 calibration jobs, so regular PR CI sits queued for a long time. Move the functional test jobs to GitHub-hosted runners; keep the hardware-bound work on self-hosted.

## Changes (`.github/workflows/mgpusim_test.yml`)

| Job | Runner |
|---|---|
| Compile, Lint, Unit Test, Deterministicity, Disassembler | `ubuntu-latest` |
| GCN3 Emulation, GCN3 Single-GPU Timing, CDNA3 Emulation, CDNA3 Single-GPU Timing | `group: Github-Large-1` |

The four acceptance jobs run `./acceptance` without `-no-parallel`, so each exercises the `parallel: true` cases in `amd/tests/acceptance/cases.go` (parallel engine). Those need real cores, so they go to the `Github-Large-1` multi-core group rather than a 2-core free runner.

**Unchanged / still self-hosted:** `mi300a_calibration.yml` (needs the MI300 hardware) and `benchmark.yml` (heavy benchmark matrix, Fedora-specific setup).

## Notes

- The `Install build dependencies` steps are guarded by `if command -v dnf`, so they no-op on Ubuntu; ubuntu-latest ships gcc, so the CGO/sqlite builds still work.
- For `pull_request` runs GitHub uses the workflow from the PR's own branch, so existing open PRs pick this up only after merging/rebasing `main` (or by applying it to their branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
