### PR TITLE
amd/timing/cu: attribute wavefront execution gaps with milestones (+ fetch location)

### DIFF
--- a/amd/timing/cp/cpMiddleware.go
+++ b/amd/timing/cp/cpMiddleware.go
@@ -148,7 +148,7 @@ func (m *cpMiddleware) processLaunchKernelReq(
 	tracing.AddMilestone(m.comp, tracing.Milestone{
 		TaskID: tracing.MsgIDAtIncomingBuffer(req, m.comp),
 		Kind:   tracing.MilestoneKindHardwareResource,
-		What:   "dispatcher",
+		What:   m.comp.Name() + ".dispatcher",
 	})
 
 	m.toDriver().RetrieveIncoming()

--- a/amd/timing/cp/dma.go
+++ b/amd/timing/cp/dma.go
@@ -313,7 +313,7 @@ func (m *dmaMiddleware) parseFromCP() bool {
 	tracing.AddMilestone(m.comp, tracing.Milestone{
 		TaskID: tracing.MsgIDAtIncomingBuffer(req, m.comp),
 		Kind:   tracing.MilestoneKindHardwareResource,
-		What:   "processing slot",
+		What:   m.comp.Name() + ".processing-slot",
 	})
 
 	m.toCP().RetrieveIncoming()

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -347,6 +347,11 @@ func (cu *ComputeUnit) endInflightTracingTasks() {
 			}
 
 			if inst := wf.DynamicInst(); inst != nil {
+				// This running inst's task is force-ended here, bypassing
+				// logInstTask, so keep the in-flight counter balanced.
+				if wf.InFlightInsts > 0 {
+					wf.InFlightInsts--
+				}
 				tracing.EndTaskOnReset(cu.comp, inst.ID)
 			}
 		}
@@ -581,6 +586,12 @@ func (cu *ComputeUnit) handleFetchReturn(
 
 	wf.IsFetching = false
 	wf.LastFetchTime = cu.CurrentTime()
+
+	if wf.InFlightInsts == 0 {
+		// The fetched instruction bytes arrived while nothing was executing: the
+		// interval since the fetch went out was spent waiting for this data.
+		cu.markWfMilestone(wf, tracing.MilestoneKindData, "inst_fetch")
+	}
 
 	tracing.TraceReqFinalize(cu.comp, info.Req)
 	tracing.EndTask(cu.comp, tracing.TaskEnd{ID: info.FetchTaskID})
@@ -850,15 +861,48 @@ func (cu *ComputeUnit) flushCUBuffers() {
 	cu.InFlightVectorMemAccess = nil
 }
 
+// markWfMilestone records a milestone on the wavefront task itself (TaskID
+// wf.UID), not on its instruction. These tile the wavefront's life into
+// execution (work) and the reasons for a gap between instructions — waiting
+// to fetch (hardware_resource), waiting for the fetched bytes (data), and
+// waiting for the exec unit to accept the issue (hardware_resource). They are
+// only emitted while nothing is in flight (see logInstTask), so they never
+// overlap and a prefetch overlapping execution stays silent.
+func (cu *ComputeUnit) markWfMilestone(
+	wf *wavefront.Wavefront, kind tracing.MilestoneKind, what string,
+) {
+	tracing.AddMilestone(cu.comp, tracing.Milestone{
+		TaskID: wf.UID,
+		Kind:   kind,
+		What:   what,
+	})
+}
+
 func (cu *ComputeUnit) logInstTask(
 	wf *wavefront.Wavefront,
 	inst *wavefront.Inst,
 	completed bool,
 ) {
 	if completed {
+		wf.InFlightInsts--
+		if wf.InFlightInsts == 0 {
+			// The last in-flight instruction finished: close the execution burst
+			// as work, so the gap that follows is attributed separately.
+			cu.markWfMilestone(wf, tracing.MilestoneKindWork, "execution")
+		}
 		tracing.EndTask(cu.comp, tracing.TaskEnd{ID: inst.ID})
 		return
 	}
+
+	if wf.InFlightInsts == 0 {
+		// Issuing after a gap (nothing was in flight): the time since the last
+		// milestone was spent waiting to issue this instruction — decode is ~1
+		// cycle, so it is dominated by waiting for the exec unit to accept the
+		// wave. Attribute it to that unit as a hardware resource.
+		cu.markWfMilestone(wf, tracing.MilestoneKindHardwareResource,
+			cu.execUnitToString(inst.ExeUnit))
+	}
+	wf.InFlightInsts++
 
 	tracing.StartTask(cu.comp, tracing.TaskStart{
 		ID:       inst.ID,

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -461,6 +461,10 @@ func (cu *ComputeUnit) handleMapWGReq(
 					ParentID: tracing.MsgIDAtReceiver(req, cu.comp),
 					Kind:     "wavefront",
 					What:     "wavefront",
+					// The sampled fast path forgot the location, so the wavefront task
+					// fell back to the bare CU name and collided with fetch. Pin it to
+					// the same .WFPool location the normal path uses.
+					Location: cu.comp.Name() + ".WFPool",
 				})
 			}
 		}

--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -900,7 +900,7 @@ func (cu *ComputeUnit) logInstTask(
 		// cycle, so it is dominated by waiting for the exec unit to accept the
 		// wave. Attribute it to that unit as a hardware resource.
 		cu.markWfMilestone(wf, tracing.MilestoneKindHardwareResource,
-			cu.execUnitToString(inst.ExeUnit))
+			cu.comp.Name()+"."+cu.execUnitToString(inst.ExeUnit))
 	}
 	wf.InFlightInsts++
 

--- a/amd/timing/cu/computeunit_test.go
+++ b/amd/timing/cu/computeunit_test.go
@@ -206,7 +206,7 @@ var _ = Describe("ComputeUnit", func() {
 			wf *wavefront.Wavefront
 		)
 		BeforeEach(func() {
-			wf = new(wavefront.Wavefront)
+			wf = wavefront.NewWavefront(kernels.NewWavefront())
 			inst := wavefront.NewInst(nil)
 			wf.SetDynamicInst(inst)
 			wf.SetPC(0x1000)

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -200,7 +200,7 @@ func (s *SchedulerImpl) DoFetch() bool {
 			// instruction available, waiting on the fetch path. (A prefetch issued
 			// while an instruction executes leaves InFlightInsts > 0 and is silent.)
 			s.cu.markWfMilestone(wf, tracing.MilestoneKindHardwareResource,
-				"inst_fetch")
+				s.cu.comp.Name()+".InstFetcher")
 		}
 		tracing.TraceReqInitiate(s.cu.comp, req, info.FetchTaskID)
 	}

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -358,6 +358,12 @@ func (s *SchedulerImpl) evalSEndPgm(
 	// executing paths close it via logInstTask).
 	s.markMemDrained(wf, "s_endpgm")
 
+	// Cap the wavefront's final execution burst with a work milestone before it
+	// completes. The tail can keep InFlightInsts > 0 (e.g. a long outstanding
+	// VMem) right up to S_ENDPGM, so no count->0 work milestone fires on its own;
+	// without this the busy tail would be left unattributed.
+	s.cu.markWfMilestone(wf, tracing.MilestoneKindWork, "execution")
+
 	if allCompleted {
 		s.sendWGCompletionMessage(wf.WG)
 

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -195,6 +195,13 @@ func (s *SchedulerImpl) DoFetch() bool {
 			// also used to fall back to the bare CU name).
 			Location: s.cu.comp.Name() + ".InstFetcher",
 		})
+		if wf.InFlightInsts == 0 {
+			// Fetching while nothing is in flight: the wavefront is stalled with no
+			// instruction available, waiting on the fetch path. (A prefetch issued
+			// while an instruction executes leaves InFlightInsts > 0 and is silent.)
+			s.cu.markWfMilestone(wf, tracing.MilestoneKindHardwareResource,
+				"inst_fetch")
+		}
 		tracing.TraceReqInitiate(s.cu.comp, req, info.FetchTaskID)
 	}
 

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -188,6 +188,12 @@ func (s *SchedulerImpl) DoFetch() bool {
 			ParentID: wf.UID,
 			Kind:     "fetch",
 			What:     "fetch",
+			// Give instruction fetch its own unit location instead of letting it
+			// fall back to the bare CU name (singleKindLocation's default). That
+			// keeps "one location, one kind": the bare CU name is no longer a task
+			// row, and fetch can't collide with the sampled wavefront task (which
+			// also used to fall back to the bare CU name).
+			Location: s.cu.comp.Name() + ".InstFetcher",
 		})
 		tracing.TraceReqInitiate(s.cu.comp, req, info.FetchTaskID)
 	}

--- a/amd/timing/cu/vectormemoryunit.go
+++ b/amd/timing/cu/vectormemoryunit.go
@@ -259,7 +259,7 @@ func (u *VectorMemoryUnit) executeFlatLoad(
 	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
 		TaskID: wave.DynamicInst().ID,
 		Kind:   tracing.MilestoneKindHardwareResource,
-		What:   "vmem-inflight",
+		What:   u.cu.comp.Name() + ".vmem-inflight-reg",
 	})
 	u.startIssueSubtask(wave.DynamicInst())
 
@@ -309,7 +309,7 @@ func (u *VectorMemoryUnit) executeFlatStore(
 	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
 		TaskID: wave.DynamicInst().ID,
 		Kind:   tracing.MilestoneKindHardwareResource,
-		What:   "vmem-inflight",
+		What:   u.cu.comp.Name() + ".vmem-inflight-reg",
 	})
 	u.startIssueSubtask(wave.DynamicInst())
 

--- a/amd/timing/wavefront/wavefront.go
+++ b/amd/timing/wavefront/wavefront.go
@@ -65,6 +65,13 @@ type Wavefront struct {
 	OutstandingScalarMemAccess int
 	OutstandingVectorMemAccess int
 
+	// InFlightInsts counts this wavefront's instruction tasks currently in
+	// flight (issued but not yet completed). When it is zero the wavefront has
+	// nothing executing — a real gap — and its fetch/issue stalls are
+	// attributed with milestones; while it is non-zero a concurrent prefetch is
+	// silent (the wavefront is making progress, so it is not blocked).
+	InFlightInsts int
+
 	// ScoreboardData holds per-wavefront register scoreboard state.
 	// When register scoreboard is enabled, this contains a *cu.Scoreboard
 	// (stored as interface{} to avoid circular imports).

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/onsi/ginkgo/v2 v2.25.1
 	github.com/onsi/gomega v1.38.1
-	github.com/sarchlab/akita/v5 v5.0.0-beta.7
+	github.com/sarchlab/akita/v5 v5.0.0-beta.8
 	github.com/tebeka/atexit v0.3.0
 	go.uber.org/mock v0.6.0
 	gonum.org/v1/gonum v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
-github.com/sarchlab/akita/v5 v5.0.0-beta.7 h1:ciT8jXGYXG4bXFGiu6ReQLQkM0ZuGhL1Kw3WgdCciHI=
-github.com/sarchlab/akita/v5 v5.0.0-beta.7/go.mod h1:/2uOHfnAJFZCMufMx7a5tXUsdAdgP2XiL9ssc2C4Za8=
+github.com/sarchlab/akita/v5 v5.0.0-beta.8 h1:6BfkgKn4pygJm9KwtNoZAR/g5Qxtykp+BCMhz2Xa2mg=
+github.com/sarchlab/akita/v5 v5.0.0-beta.8/go.mod h1:/2uOHfnAJFZCMufMx7a5tXUsdAdgP2XiL9ssc2C4Za8=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
> **Draft — depends on akita.** The wavefront milestones only tile a wavefront's
> whole life once akita's milestone-dedup relaxation ships (akita **#437**);
> against the current released akita they are collapsed to one milestone per
> `(kind, what)` per task. This compiles and runs on beta.7 today; mark ready
> after bumping to the akita release that includes #437.

Make a wavefront task's execution explainable, and tidy up CU trace locations.

## Wavefront gap attribution (the main change)
The `wavefront` task spans a whole kernel but carried no milestones, so its big
gaps between instruction bursts looked unexplained. Instrument the wavefront task
(`wf.UID`) so every moment has a cause, using an `InFlightInsts` counter to know
when nothing is executing. Milestones are recorded only during a real gap
(InFlightInsts == 0), so they never overlap and a prefetch overlapping execution
is silent:

- `work : execution` — while ≥1 instruction is in flight
- `hardware_resource : inst_fetch` — fetching with no instruction available
- `data : inst_fetch` — waiting for the fetched bytes
- `hardware_resource : <ExeUnit>` — at issue, waiting for that unit to accept the wave
- a `work` milestone at `S_ENDPGM` caps the final in-flight tail

On a 1M FIR the big "ready-but-not-issued" gaps resolve to exec-unit contention
and fetch-data latency, and every wavefront's milestones tile to its end.

## Trace-location hygiene
- Instruction fetch gets its own `.InstFetcher` unit location instead of falling
  back to the bare CU name (keeps "one location, one kind").
- The sampled-mode wavefront task is pinned to `.WFPool` (it had fallen back to
  the bare CU name and collided with fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
