### PR TITLE
amd/samples/runner: record mgpusim's own source into vis traces

### DIFF
--- a/amd/samples/runner/runner.go
+++ b/amd/samples/runner/runner.go
@@ -75,6 +75,7 @@ func (r *Runner) initSimulation() {
 
 	if *visTracing {
 		builder = builder.WithVisTracingOnStart()
+		builder = withRecordedSource(builder)
 	}
 
 	// Only honor -metric-file-name when it is explicitly set, so the

--- a/amd/samples/runner/source.go
+++ b/amd/samples/runner/source.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/sarchlab/akita/v5/simulation"
+)
+
+// mgpusimModulePath is mgpusim's Go module path. The source archive recorded into
+// a vis trace is keyed by it (mirrors how Akita keys its own source).
+const mgpusimModulePath = "github.com/sarchlab/mgpusim/v5"
+
+// withRecordedSource registers mgpusim's own source tree so it is archived into
+// the vis trace alongside Akita's, making the trace self-describing (e.g. for
+// DaisenBot). It reads from disk like Akita does for its own source; the recorder
+// keeps only non-test .go plus go.mod and prunes VCS/vendor/.claude dirs, so no
+// kernel binaries or fixtures are recorded. When the source is not on disk (e.g.
+// a -trimpath build), nothing is registered — matching Akita's behavior.
+func withRecordedSource(b simulation.Builder) simulation.Builder {
+	dir, ok := mgpusimSourceDir()
+	if !ok {
+		return b
+	}
+
+	return b.WithSourceFS(mgpusimModulePath, os.DirFS(dir))
+}
+
+// mgpusimSourceDir returns the on-disk root of the mgpusim module and true if
+// found. It locates itself from the compiled-in path of this file and walks up to
+// the enclosing go.mod that declares mgpusimModulePath, so it resolves whether
+// mgpusim is the main module, a module-cache dependency, or a replace target.
+func mgpusimSourceDir() (string, bool) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok || !filepath.IsAbs(file) {
+		return "", false
+	}
+
+	dir := filepath.Dir(file)
+	for {
+		data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+		if err == nil && moduleLineIs(data, mgpusimModulePath) {
+			if _, statErr := os.Stat(dir); statErr != nil {
+				return "", false
+			}
+			return dir, true
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// moduleLineIs reports whether a go.mod's `module` line declares modulePath.
+func moduleLineIs(gomod []byte, modulePath string) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(gomod))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[0] == "module" {
+			return fields[1] == modulePath
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Akita already records its framework source into a vis trace's `source` table, so
a trace is self-describing (e.g. DaisenBot can read it). But mgpusim's own
source — the component/timing code that actually produced the trace — was missing:
the runner registered no source root, so a trace only ever carried
`github.com/sarchlab/akita/v5`.

Now every `-trace-vis` run records mgpusim's source too. The runner calls
`simulation.WithSourceFS` whenever vis tracing is enabled, mirroring how Akita
records itself:

- find the module root from this file's compiled-in path (`runtime.Caller` → walk
  up to the `go.mod` declaring `github.com/sarchlab/mgpusim/v5`),
- hand the recorder an `os.DirFS` of it.

The recorder keeps only non-test `.go` + `go.mod` and prunes `.git`/`.claude`/
vendor/testdata/dist, so **no kernel binaries, tests, or fixtures** are recorded.
When the source isn't on disk (e.g. a `-trimpath` build), nothing is registered —
same as Akita.

## Cost
Tiny: the source is a gzip'd tar base64'd into one TEXT column — ~0.3 MB for
mgpusim (and ~0.3 MB for Akita), negligible next to GB-scale trace data.

## Verification
A FIR `-trace-vis` run's `source` table now has both
`github.com/sarchlab/akita/v5` and `github.com/sarchlab/mgpusim/v5`; the mgpusim
archive decodes to **349 non-test `.go` + `go.mod`, zero binaries**, no
`.git`/`.claude`/`_test` leakage. `go build ./...`, `go vet`, and golangci-lint
(0 issues) pass. Builds against released akita beta.7 (no dependency bump needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
