### PR TITLE
[codex] Trace scalar memory issue work

### DIFF
--- a/amd/timing/cu/computeunit.go
+++ b/amd/timing/cu/computeunit.go
@@ -576,6 +576,7 @@ func (cu *ComputeUnit) handleFetchReturn(
 	info := cu.InFlightInstFetch[matchIdx]
 	wf := info.Wavefront
 	addr := info.Address
+	wasWaitingForFetch := wf.InFlightInsts == 0 && !wfHasInstructionReady(wf)
 	cu.InFlightInstFetch = append(
 		cu.InFlightInstFetch[:matchIdx],
 		cu.InFlightInstFetch[matchIdx+1:]...)
@@ -587,7 +588,7 @@ func (cu *ComputeUnit) handleFetchReturn(
 	wf.IsFetching = false
 	wf.LastFetchTime = cu.CurrentTime()
 
-	if wf.InFlightInsts == 0 {
+	if wasWaitingForFetch {
 		// The fetched instruction bytes arrived while nothing was executing: the
 		// interval since the fetch went out was spent waiting for this data.
 		cu.markWfMilestone(wf, tracing.MilestoneKindData, "inst_fetch")
@@ -853,6 +854,23 @@ func (cu *ComputeUnit) removeStaleInstBuffer(wf *wavefront.Wavefront) {
 			wf.InstBufferStartPC += 64
 		}
 	}
+}
+
+func wfHasInstructionReady(wf *wavefront.Wavefront) bool {
+	if wf.InstToIssue != nil {
+		return true
+	}
+
+	if len(wf.InstBuffer) == 0 || wf.PC() < wf.InstBufferStartPC {
+		return false
+	}
+
+	offset := wf.PC() - wf.InstBufferStartPC
+	if offset > uint64(len(wf.InstBuffer)) {
+		return false
+	}
+
+	return len(wf.InstBuffer[int(offset):]) >= 4
 }
 
 func (cu *ComputeUnit) flushCUBuffers() {

--- a/amd/timing/cu/decodeunit.go
+++ b/amd/timing/cu/decodeunit.go
@@ -3,6 +3,8 @@ package cu
 import (
 	"log"
 
+	"github.com/sarchlab/akita/v5/timing"
+	"github.com/sarchlab/akita/v5/tracing"
 	"github.com/sarchlab/mgpusim/v5/amd/timing/wavefront"
 )
 
@@ -14,6 +16,9 @@ type DecodeUnit struct {
 	toDecode []*wavefront.Wavefront
 	decoded  bool
 
+	decodeTaskIDs map[uint64]uint64
+	decodeDone    map[uint64]bool
+
 	isIdle bool
 }
 
@@ -23,6 +28,8 @@ func NewDecodeUnit(cu *ComputeUnit) *DecodeUnit {
 	du.cu = cu
 	du.decoded = false
 	du.toDecode = make([]*wavefront.Wavefront, 0, 4)
+	du.decodeTaskIDs = make(map[uint64]uint64)
+	du.decodeDone = make(map[uint64]bool)
 	return du
 }
 
@@ -55,6 +62,7 @@ func (du *DecodeUnit) AcceptWave(
 
 	du.toDecode = append(du.toDecode, wave)
 	du.decoded = false
+	du.startDecodeSubtask(wave.DynamicInst())
 }
 
 // Run decodes the instruction and sends the instruction to the next pipeline
@@ -68,7 +76,15 @@ func (du *DecodeUnit) Run() bool {
 		execUnit := du.ExecUnits[simdID]
 
 		if execUnit.CanAcceptWave() {
+			inst := wave.DynamicInst()
+			du.endDecodeSubtask(inst)
+			if inst != nil && du.decodeDone[inst.ID] {
+				du.markExecUnitReady(wave)
+			}
 			execUnit.AcceptWave(wave)
+			if inst != nil {
+				delete(du.decodeDone, inst.ID)
+			}
 			madeProgress = true
 		} else {
 			remaining = append(remaining, wave)
@@ -77,6 +93,13 @@ func (du *DecodeUnit) Run() bool {
 	du.toDecode = remaining
 
 	if len(du.toDecode) > 0 && !du.decoded {
+		for _, wave := range du.toDecode {
+			inst := wave.DynamicInst()
+			du.endDecodeSubtask(inst)
+			if inst != nil {
+				du.decodeDone[inst.ID] = true
+			}
+		}
 		du.decoded = true
 		return true
 	}
@@ -84,7 +107,64 @@ func (du *DecodeUnit) Run() bool {
 	return madeProgress
 }
 
+func (du *DecodeUnit) startDecodeSubtask(inst *wavefront.Inst) {
+	if inst == nil {
+		return
+	}
+
+	taskID := timing.GetIDGenerator().Generate()
+	tracing.StartTask(du.cu.comp, tracing.TaskStart{
+		ID:       taskID,
+		ParentID: inst.ID,
+		Kind:     "pipeline",
+		What:     "decode",
+	})
+	du.decodeTaskIDs[inst.ID] = taskID
+}
+
+func (du *DecodeUnit) endDecodeSubtask(inst *wavefront.Inst) {
+	if inst == nil {
+		return
+	}
+
+	taskID, ok := du.decodeTaskIDs[inst.ID]
+	if !ok {
+		return
+	}
+
+	tracing.EndTask(du.cu.comp, tracing.TaskEnd{ID: taskID})
+	tracing.AddMilestone(du.cu.comp, tracing.Milestone{
+		TaskID: inst.ID,
+		Kind:   tracing.MilestoneKindWork,
+		What:   "decode",
+	})
+	delete(du.decodeTaskIDs, inst.ID)
+}
+
+func (du *DecodeUnit) markExecUnitReady(wave *wavefront.Wavefront) {
+	if wave.DynamicInst() == nil {
+		return
+	}
+
+	tracing.AddMilestone(du.cu.comp, tracing.Milestone{
+		TaskID: wave.DynamicInst().ID,
+		Kind:   tracing.MilestoneKindHardwareResource,
+		What: du.cu.comp.Name() + "." +
+			du.cu.execUnitToString(wave.DynamicInst().ExeUnit),
+	})
+}
+
 // Flush clear the unit
 func (du *DecodeUnit) Flush() {
+	for instID, taskID := range du.decodeTaskIDs {
+		tracing.EndTask(du.cu.comp, tracing.TaskEnd{ID: taskID})
+		tracing.AddMilestone(du.cu.comp, tracing.Milestone{
+			TaskID: instID,
+			Kind:   tracing.MilestoneKindWork,
+			What:   "decode",
+		})
+		delete(du.decodeTaskIDs, instID)
+	}
+	du.decodeDone = make(map[uint64]bool)
 	du.toDecode = du.toDecode[:0]
 }

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -212,6 +212,212 @@ func TestVectorMemDataReturnRecordsDataMilestone(t *testing.T) {
 	}
 }
 
+// A fetch-ahead request can run while the wavefront already has instruction
+// bytes for its current PC. That fetch is not the wavefront's blocker; if the
+// ready instruction cannot issue yet, the later issue milestone should name the
+// execution unit instead.
+func TestFetchAheadDoesNotRecordFetcherMilestone(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	cu.comp.State.InstMem = "InstMem"
+	cu.ToInstMem = newFakePort("CU.ToInstMem")
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	wf.SetPC(0x100)
+	wf.InstBufferStartPC = 0x100
+	wf.InstBuffer = make([]byte, 64)
+
+	fetchArbiter := newMockWfArbitor()
+	fetchArbiter.wfsToReturn = append(fetchArbiter.wfsToReturn,
+		[]*wavefront.Wavefront{wf})
+	s := NewScheduler(cu, fetchArbiter, nil)
+
+	s.DoFetch()
+
+	if rec.has(wf.UID, tracing.MilestoneKindHardwareResource,
+		"CU.InstFetcher") {
+		t.Fatalf("fetch-ahead should not be marked as a blocker, got %+v",
+			rec.milestones)
+	}
+}
+
+// If instruction bytes were already available before a prefetch response
+// arrived, that response did not unblock the wavefront. Do not stamp a
+// data/inst_fetch milestone over an execution-unit stall.
+func TestFetchAheadReturnDoesNotRecordDataMilestone(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	wf.SetPC(0x100)
+	wf.InstBufferStartPC = 0x100
+	wf.InstBuffer = make([]byte, 64)
+
+	req := memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{
+			ID: timing.GetIDGenerator().Generate(),
+		},
+		Address:        0x140,
+		AccessByteSize: 64,
+	}
+	cu.InFlightInstFetch = append(cu.InFlightInstFetch, &InstFetchReqInfo{
+		Wavefront:   wf,
+		Req:         req,
+		Address:     0x140,
+		FetchTaskID: timing.GetIDGenerator().Generate(),
+	})
+
+	cu.handleFetchReturn(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			RspTo: req.ID,
+		},
+		Data: make([]byte, 64),
+	})
+
+	if rec.has(wf.UID, tracing.MilestoneKindData, "inst_fetch") {
+		t.Fatalf("fetch-ahead return should not be marked as data wait, got %+v",
+			rec.milestones)
+	}
+}
+
+func TestBlockingFetchReturnRecordsDataMilestone(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	wf.SetPC(0x100)
+	wf.InstBufferStartPC = 0x100
+
+	req := memprotocol.ReadReq{
+		MsgMeta: messaging.MsgMeta{
+			ID: timing.GetIDGenerator().Generate(),
+		},
+		Address:        0x100,
+		AccessByteSize: 64,
+	}
+	cu.InFlightInstFetch = append(cu.InFlightInstFetch, &InstFetchReqInfo{
+		Wavefront:   wf,
+		Req:         req,
+		Address:     0x100,
+		FetchTaskID: timing.GetIDGenerator().Generate(),
+	})
+
+	cu.handleFetchReturn(memprotocol.DataReadyRsp{
+		MsgMeta: messaging.MsgMeta{
+			ID:    timing.GetIDGenerator().Generate(),
+			RspTo: req.ID,
+		},
+		Data: make([]byte, 64),
+	})
+
+	if !rec.has(wf.UID, tracing.MilestoneKindData, "inst_fetch") {
+		t.Fatalf("blocking fetch return should be marked as data wait, got %+v",
+			rec.milestones)
+	}
+}
+
+type decodeTraceUnit struct {
+	canAccept bool
+	accepted  []*wavefront.Wavefront
+}
+
+func (u *decodeTraceUnit) CanAcceptWave() bool {
+	return u.canAccept
+}
+
+func (u *decodeTraceUnit) AcceptWave(wf *wavefront.Wavefront) {
+	u.accepted = append(u.accepted, wf)
+}
+
+func (u *decodeTraceUnit) Run() bool {
+	return false
+}
+
+func (u *decodeTraceUnit) IsIdle() bool {
+	return len(u.accepted) == 0
+}
+
+func (u *decodeTraceUnit) Flush() {}
+
+// Decode is the first pipeline interval inside an instruction task. Record it
+// explicitly so the instruction timeline does not have an unexplained prefix
+// before the execution unit's own subtasks begin.
+func TestDecodeRecordsWorkMilestone(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	du := NewDecodeUnit(cu)
+	exec := &decodeTraceUnit{canAccept: true}
+	du.AddExecutionUnit(exec)
+
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	inst := wavefront.NewInst(insts.NewInst())
+	inst.ExeUnit = insts.ExeUnitScalar
+	wf.SetDynamicInst(inst)
+
+	du.AcceptWave(wf)
+	du.Run()
+
+	if !rec.has(inst.ID, tracing.MilestoneKindWork, "decode") {
+		t.Fatalf("expected a work milestone for decode, got %+v",
+			rec.milestones)
+	}
+	if _, ok := du.decodeTaskIDs[inst.ID]; ok {
+		t.Fatal("the decode subtask should be closed after execution-unit admission")
+	}
+	if len(exec.accepted) != 1 {
+		t.Fatalf("expected decode to forward the wavefront, got %d accepts",
+			len(exec.accepted))
+	}
+}
+
+// A scalar-memory instruction spends a few cycles in the scalar unit before its
+// read request exists. Mark that interval as issue work so the later data
+// milestone starts at the memory request, not at the instruction task start.
+func TestScalarMemIssueRecordsWorkMilestone(t *testing.T) {
+	cu := newTestComputeUnit("CU", newFakeEngine())
+	rec := &cuMilestoneRecorder{}
+	tracing.CollectTrace(cu.comp, rec)
+
+	cu.ToScalarMem = newFakePort("CU.ToScalarMem")
+	cu.comp.State.ScalarMem = "ScalarMem"
+	su := NewScalarUnit(cu, nil)
+	su.log2CachelineSize = 6
+
+	wf := wavefront.NewWavefront(kernels.NewWavefront())
+	regAccessor := newMockRegFileAccessor()
+	wf.RegAccessor = regAccessor
+
+	inst := wavefront.NewInst(insts.NewInst())
+	inst.FormatType = insts.SMEM
+	inst.Opcode = 0
+	inst.Data = insts.NewSRegOperand(0, 0, 1)
+	inst.Base = insts.NewSRegOperand(2, 2, 2)
+	inst.Offset = insts.NewIntOperand(0, 0)
+	wf.SetDynamicInst(inst)
+
+	baseReg := insts.SReg(2)
+	regAccessor.setRegValue(baseReg, 2, 0, wf.SRegOffset,
+		insts.Uint64ToBytes(0x1000)[:8])
+
+	su.AcceptWave(wf)
+	su.Run() // read -> exec
+	su.Run() // exec -> readBuf/in-flight scalar access
+
+	if !rec.has(inst.ID, tracing.MilestoneKindWork, "smem_issue") {
+		t.Fatalf("expected a work milestone for SMEM issue, got %+v",
+			rec.milestones)
+	}
+	if _, ok := su.issueTaskIDs[inst.ID]; ok {
+		t.Fatal("the SMEM issue subtask should be closed after request admission")
+	}
+}
+
 // Sending the first vector-memory transaction closes the issue subtask and
 // records a "work" milestone (not a hardware_resource one): the coalescing /
 // transaction-issue phase is the unit doing work, and it is backed by the

--- a/amd/timing/cu/scalarunit.go
+++ b/amd/timing/cu/scalarunit.go
@@ -25,6 +25,12 @@ type ScalarUnit struct {
 	readBufSize int
 	readBuf     []memprotocol.ReadReq
 
+	// issueTaskIDs maps an SMEM instruction's task ID to the "pipeline" subtask
+	// that records scalar-address/read-request issue work. The subtask closes
+	// when the requests are admitted into readBuf, so the later data milestone
+	// covers only the actual memory round trip.
+	issueTaskIDs map[uint64]uint64
+
 	log2CachelineSize uint64
 
 	isIdle bool
@@ -41,6 +47,7 @@ func NewScalarUnit(
 	u.alu = alu
 	u.readBufSize = 16
 	u.readBuf = make([]memprotocol.ReadReq, 0, u.readBufSize)
+	u.issueTaskIDs = make(map[uint64]uint64)
 	return u
 }
 
@@ -59,6 +66,37 @@ func (u *ScalarUnit) IsIdle() bool {
 // AcceptWave moves one wavefront into the read buffer of the Scalar unit
 func (u *ScalarUnit) AcceptWave(wave *wavefront.Wavefront) {
 	u.toRead = wave
+	inst := wave.Inst()
+	dynInst := wave.DynamicInst()
+	if inst != nil && dynInst != nil && inst.FormatType == insts.SMEM {
+		u.startIssueSubtask(dynInst)
+	}
+}
+
+func (u *ScalarUnit) startIssueSubtask(inst *wavefront.Inst) {
+	taskID := timing.GetIDGenerator().Generate()
+	tracing.StartTask(u.cu.comp, tracing.TaskStart{
+		ID:       taskID,
+		ParentID: inst.ID,
+		Kind:     "pipeline",
+		What:     "smem_issue",
+	})
+	u.issueTaskIDs[inst.ID] = taskID
+}
+
+func (u *ScalarUnit) endIssueSubtask(inst *wavefront.Inst) {
+	taskID, ok := u.issueTaskIDs[inst.ID]
+	if !ok {
+		return
+	}
+
+	tracing.EndTask(u.cu.comp, tracing.TaskEnd{ID: taskID})
+	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
+		TaskID: inst.ID,
+		Kind:   tracing.MilestoneKindWork,
+		What:   "smem_issue",
+	})
+	delete(u.issueTaskIDs, inst.ID)
 }
 
 // Run executes three pipeline stages that are controlled by the ScalarUnit
@@ -170,6 +208,8 @@ func (u *ScalarUnit) executeSMEMLoad(byteSize int) bool {
 		curr += bytesLeftInCacheline
 	}
 
+	u.endIssueSubtask(inst)
+
 	u.toExec.OutstandingScalarMemAccess++
 	u.cu.UpdatePCAndSetReady(u.toExec)
 	u.toExec = nil
@@ -245,4 +285,13 @@ func (u *ScalarUnit) Flush() {
 	u.toExec = nil
 	u.toWrite = nil
 	u.readBuf = nil
+	for instID, taskID := range u.issueTaskIDs {
+		tracing.EndTask(u.cu.comp, tracing.TaskEnd{ID: taskID})
+		tracing.AddMilestone(u.cu.comp, tracing.Milestone{
+			TaskID: instID,
+			Kind:   tracing.MilestoneKindWork,
+			What:   "smem_issue",
+		})
+		delete(u.issueTaskIDs, instID)
+	}
 }

--- a/amd/timing/cu/scheduler.go
+++ b/amd/timing/cu/scheduler.go
@@ -195,10 +195,13 @@ func (s *SchedulerImpl) DoFetch() bool {
 			// also used to fall back to the bare CU name).
 			Location: s.cu.comp.Name() + ".InstFetcher",
 		})
-		if wf.InFlightInsts == 0 {
+		if wf.InFlightInsts == 0 && !wfHasInstructionReady(wf) {
 			// Fetching while nothing is in flight: the wavefront is stalled with no
 			// instruction available, waiting on the fetch path. (A prefetch issued
-			// while an instruction executes leaves InFlightInsts > 0 and is silent.)
+			// while an instruction executes leaves InFlightInsts > 0 and is silent;
+			// a fetch-ahead with decoded/available bytes is also silent because the
+			// real blocker is the execution unit that has not accepted the ready
+			// instruction yet.
 			s.cu.markWfMilestone(wf, tracing.MilestoneKindHardwareResource,
 				s.cu.comp.Name()+".InstFetcher")
 		}


### PR DESCRIPTION
## Summary

- add explicit `pipeline/decode` child tasks and `work/decode` milestones for instruction decode intervals
- add explicit `pipeline/smem_issue` child tasks and `work/smem_issue` milestones before scalar-memory requests are admitted
- keep the later `data/smem` milestone aligned with the actual memory request/data interval
- keep fetch-ahead requests/responses from claiming the wavefront blocking reason once an instruction is already ready
- add CU regression coverage for decode and scalar-memory issue tracing

## Validation

- `go test ./amd/timing/cu`
- regenerated FIR 1M trace from commit `49cd6805`
- validated trace ordering: decode -> SMEM issue -> read request -> data
- validated fetch-ahead attribution: fetch tasks remain visible, but ready-instruction stalls are attributed to the target execution unit instead of `InstFetcher`/`inst_fetch`
