### PR TITLE
amd/cu: qualify pipeline-task locations with the CU name

### DIFF
--- a/amd/timing/cu/cubuilder.go
+++ b/amd/timing/cu/cubuilder.go
@@ -168,6 +168,7 @@ func (b *Builder) equipScalarUnits(cu *ComputeUnit) {
 	cu.BranchUnit = NewBranchUnit(cu, b.resources.ALU)
 
 	scalarDecoder := NewDecodeUnit(cu)
+	scalarDecoder.stage = "decode_scalar"
 	cu.ScalarDecoder = scalarDecoder
 	scalarUnit := NewScalarUnit(cu, b.resources.ALU)
 	scalarUnit.log2CachelineSize = b.spec.Log2CachelineSize
@@ -179,6 +180,7 @@ func (b *Builder) equipScalarUnits(cu *ComputeUnit) {
 
 func (b *Builder) equipSIMDUnits(cu *ComputeUnit, name string) {
 	vectorDecoder := NewDecodeUnit(cu)
+	vectorDecoder.stage = "decode_vector"
 	cu.VectorDecoder = vectorDecoder
 	for i := 0; i < b.spec.SIMDCount; i++ {
 		simdName := fmt.Sprintf(name+".SIMD%d", i)
@@ -196,6 +198,7 @@ func (b *Builder) equipSIMDUnits(cu *ComputeUnit, name string) {
 
 func (b *Builder) equipLDSUnit(cu *ComputeUnit) {
 	ldsDecoder := NewDecodeUnit(cu)
+	ldsDecoder.stage = "decode_lds"
 	cu.LDSDecoder = ldsDecoder
 
 	ldsUnit := NewLDSUnit(cu, b.resources.ALU)
@@ -208,6 +211,7 @@ func (b *Builder) equipLDSUnit(cu *ComputeUnit) {
 
 func (b *Builder) equipVectorMemoryUnit(cu *ComputeUnit, name string) {
 	vectorMemDecoder := NewDecodeUnit(cu)
+	vectorMemDecoder.stage = "decode_vmem"
 	cu.VectorMemDecoder = vectorMemDecoder
 
 	coalescer := &defaultCoalescer{

--- a/amd/timing/cu/decodeunit.go
+++ b/amd/timing/cu/decodeunit.go
@@ -16,6 +16,10 @@ type DecodeUnit struct {
 	toDecode []*wavefront.Wavefront
 	decoded  bool
 
+	// stage names this decoder in the CU-qualified tracing location
+	// "<cu>.<stage>" (the builder tags each decoder, e.g. "decode_scalar").
+	stage string
+
 	decodeTaskIDs map[uint64]uint64
 	decodeDone    map[uint64]bool
 
@@ -27,6 +31,7 @@ func NewDecodeUnit(cu *ComputeUnit) *DecodeUnit {
 	du := new(DecodeUnit)
 	du.cu = cu
 	du.decoded = false
+	du.stage = "decode"
 	du.toDecode = make([]*wavefront.Wavefront, 0, 4)
 	du.decodeTaskIDs = make(map[uint64]uint64)
 	du.decodeDone = make(map[uint64]bool)
@@ -117,7 +122,7 @@ func (du *DecodeUnit) startDecodeSubtask(inst *wavefront.Inst) {
 		ID:       taskID,
 		ParentID: inst.ID,
 		Kind:     "pipeline",
-		What:     "decode",
+		What:     du.cu.comp.Name() + "." + du.stage,
 	})
 	du.decodeTaskIDs[inst.ID] = taskID
 }
@@ -136,7 +141,7 @@ func (du *DecodeUnit) endDecodeSubtask(inst *wavefront.Inst) {
 	tracing.AddMilestone(du.cu.comp, tracing.Milestone{
 		TaskID: inst.ID,
 		Kind:   tracing.MilestoneKindWork,
-		What:   "decode",
+		What:   du.cu.comp.Name() + "." + du.stage,
 	})
 	delete(du.decodeTaskIDs, inst.ID)
 }

--- a/amd/timing/cu/milestone_tracing_test.go
+++ b/amd/timing/cu/milestone_tracing_test.go
@@ -363,7 +363,7 @@ func TestDecodeRecordsWorkMilestone(t *testing.T) {
 	du.AcceptWave(wf)
 	du.Run()
 
-	if !rec.has(inst.ID, tracing.MilestoneKindWork, "decode") {
+	if !rec.has(inst.ID, tracing.MilestoneKindWork, "CU.decode") {
 		t.Fatalf("expected a work milestone for decode, got %+v",
 			rec.milestones)
 	}
@@ -409,7 +409,7 @@ func TestScalarMemIssueRecordsWorkMilestone(t *testing.T) {
 	su.Run() // read -> exec
 	su.Run() // exec -> readBuf/in-flight scalar access
 
-	if !rec.has(inst.ID, tracing.MilestoneKindWork, "smem_issue") {
+	if !rec.has(inst.ID, tracing.MilestoneKindWork, "CU.smem_issue") {
 		t.Fatalf("expected a work milestone for SMEM issue, got %+v",
 			rec.milestones)
 	}
@@ -449,7 +449,7 @@ func TestVectorMemSendRecordsCoalesceWorkMilestone(t *testing.T) {
 
 	vmu.sendRequest()
 
-	if !rec.has(inst.ID, tracing.MilestoneKindWork, "coalesce") {
+	if !rec.has(inst.ID, tracing.MilestoneKindWork, "CU.coalesce") {
 		t.Fatalf("expected a work milestone at transaction send, got %+v",
 			rec.milestones)
 	}
@@ -462,7 +462,7 @@ func countCoalesceWork(rec *cuMilestoneRecorder, instID uint64) int {
 	count := 0
 	for _, m := range rec.milestones {
 		if m.TaskID == instID && m.Kind == tracing.MilestoneKindWork &&
-			m.What == "coalesce" {
+			m.What == "CU.coalesce" {
 			count++
 		}
 	}

--- a/amd/timing/cu/scalarunit.go
+++ b/amd/timing/cu/scalarunit.go
@@ -79,7 +79,7 @@ func (u *ScalarUnit) startIssueSubtask(inst *wavefront.Inst) {
 		ID:       taskID,
 		ParentID: inst.ID,
 		Kind:     "pipeline",
-		What:     "smem_issue",
+		What:     u.cu.comp.Name() + ".smem_issue",
 	})
 	u.issueTaskIDs[inst.ID] = taskID
 }
@@ -94,7 +94,7 @@ func (u *ScalarUnit) endIssueSubtask(inst *wavefront.Inst) {
 	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
 		TaskID: inst.ID,
 		Kind:   tracing.MilestoneKindWork,
-		What:   "smem_issue",
+		What:   u.cu.comp.Name() + ".smem_issue",
 	})
 	delete(u.issueTaskIDs, inst.ID)
 }
@@ -290,7 +290,7 @@ func (u *ScalarUnit) Flush() {
 		tracing.AddMilestone(u.cu.comp, tracing.Milestone{
 			TaskID: instID,
 			Kind:   tracing.MilestoneKindWork,
-			What:   "smem_issue",
+			What:   u.cu.comp.Name() + ".smem_issue",
 		})
 		delete(u.issueTaskIDs, instID)
 	}

--- a/amd/timing/cu/simdunit.go
+++ b/amd/timing/cu/simdunit.go
@@ -188,7 +188,7 @@ func (u *SIMDUnit) logPipelineTaskStart(inst *wavefront.Inst) uint64 {
 		ID:       taskID,
 		ParentID: inst.ID,
 		Kind:     "pipeline",
-		What:     u.cu.execUnitToString(inst.ExeUnit),
+		What:     u.Name() + "." + u.cu.execUnitToString(inst.ExeUnit),
 	})
 
 	return taskID

--- a/amd/timing/cu/vectormemoryunit.go
+++ b/amd/timing/cu/vectormemoryunit.go
@@ -66,7 +66,7 @@ func (u *VectorMemoryUnit) startIssueSubtask(inst *wavefront.Inst) {
 		ID:       taskID,
 		ParentID: inst.ID,
 		Kind:     "pipeline",
-		What:     "coalesce",
+		What:     u.cu.comp.Name() + ".coalesce",
 	})
 	u.issueTaskIDs[inst.ID] = taskID
 }
@@ -87,7 +87,7 @@ func (u *VectorMemoryUnit) endIssueSubtask(inst *wavefront.Inst) {
 	tracing.AddMilestone(u.cu.comp, tracing.Milestone{
 		TaskID: inst.ID,
 		Kind:   tracing.MilestoneKindWork,
-		What:   "coalesce",
+		What:   u.cu.comp.Name() + ".coalesce",
 	})
 	delete(u.issueTaskIDs, inst.ID)
 }
@@ -383,7 +383,7 @@ func (u *VectorMemoryUnit) Flush() {
 		tracing.AddMilestone(u.cu.comp, tracing.Milestone{
 			TaskID: instID,
 			Kind:   tracing.MilestoneKindWork,
-			What:   "coalesce",
+			What:   u.cu.comp.Name() + ".coalesce",
 		})
 		tracing.EndTaskOnReset(u.cu.comp, id)
 	}


### PR DESCRIPTION
The decode / smem-issue / coalesce pipeline subtasks (and the SIMD exec-pipeline task) set `What` to a bare stage name. Akita derives a `pipeline` task's location from `What` (convention: `"<component>.<stage>"`, see `singleKindLocation` in akita's tracing API), so these appeared in Daisen as three isolated top-level locations — `coalesce`, `decode`, `smem_issue` — instead of living under their compute units.

Changes:

- `What` now follows the convention for all four emitters, e.g. `GPU[1].SA[2].CU[3].coalesce`, matching akita's own pipeline emitters (`L2Cache.dir_pipeline` etc.). The paired `work` milestones use the same qualified names.
- The SIMD unit's exec-pipeline task had the same latent bug (`What: "VALU"`); it now uses the SIMD unit's own name plus the exec-unit stage.
- Each CU has four `DecodeUnit`s (scalar / vector / LDS / vmem) that would otherwise merge into one `CU.decode` location, so the builder tags each with its own stage: `decode_scalar`, `decode_vector`, `decode_lds`, `decode_vmem`.

Verified with a traced `fir -timing -trace-vis -length 4096` run: the only dot-less location left in the trace is `Driver`, all stage locations are properly nested (`GPU[1].SA[0].CU[3].coalesce`, `.smem_issue`, `.decode_*`), and the Daisen dashboard shows only Driver / GPU[1] / MMU at top level. `go test ./amd/timing/...` passes with the milestone-test expectations updated to the qualified names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)